### PR TITLE
Add basic CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required (VERSION 2.8)
+project (bspline-fortran NONE)
+enable_language (Fortran)
+
+file(GLOB SOURCES src/*.f90)
+add_library(${PROJECT_NAME} ${SOURCES})


### PR DESCRIPTION
This adds a very basic CMake configuration (using default compiler flags) which makes it easier to include this project's code in larger projects that use CMake.

Example to build a static library:
```
$ mkdir build
$ cd build
$ cmake ..
-- The Fortran compiler identification is GNU
-- Check for working Fortran compiler: gfortran
-- Check for working Fortran compiler: gfortran  -- works
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Checking whether gfortran supports Fortran 90
-- Checking whether gfortran supports Fortran 90 -- yes
-- Configuring done
-- Generating done
-- Build files have been written to: [...]/bspline-fortran/build
$ make
Scanning dependencies of target bspline-fortran
[ 25%] Building Fortran object CMakeFiles/bspline-fortran.dir/src/bspline_sub_module.f90.o
[ 50%] Building Fortran object CMakeFiles/bspline-fortran.dir/src/bspline_oo_module.f90.o
[ 75%] Building Fortran object CMakeFiles/bspline-fortran.dir/src/bspline_module.f90.o
[100%] Linking Fortran static library libbspline-fortran.a
[100%] Built target bspline-fortran
```

Building a shared library:
```
$ cmake -DBUILD_SHARED_LIBS=ON ..
```

For a debug build:
```
$ cmake -DCMAKE_BUILD_TYPE=DEBUG ..
```
