### PR TITLE
Work arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 *.app
 
 # Directories
+archive
 build
 doc
 lib

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ subroutine db5val(xval,yval,zval,qval,rval,idx,idy,idz,idq,idr,tx,ty,tz,tq,tr,nx
 
 !f(x,y,z,q,r,s)
 subroutine db6ink(x,nx,y,ny,z,nz,q,nq,r,nr,s,ns,fcn,kx,ky,kz,kq,kr,ks,iknot,tx,ty,tz,tq,tr,ts,bcoef,iflag)
-subroutine db6val(xval,yval,zval,qval,rval,sval,idx,idy,idz,idq,idr,ids,tx,ty,tz,tq,tr,ts,nx,ny,nz,nq,nr,ns,kx,ky,kz,kq,kr,ks,bcoef,f,iflag,inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos,w5,w3,w2,w1,w0,extrap)
+subroutine db6val(xval,yval,zval,qval,rval,sval,idx,idy,idz,idq,idr,ids,tx,ty,tz,tq,tr,ts,nx,ny,nz,nq,nr,ns,kx,ky,kz,kq,kr,ks,bcoef,f,iflag,inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos,w5,w4,w3,w2,w1,w0,extrap)
 ```
 
 The ```ink``` routines compute the interpolant coefficients, and the ```val``` routines evalute the interpolant at the specified value of each coordinate. The 2D and 3D routines are extensively refactored versions of the original routines from the [NIST Core Math Library](http://www.nist.gov/itl/math/mcsd-software.cfm).  The others are new, and are simply extensions of the same algorithm into the other dimensions.

--- a/README.md
+++ b/README.md
@@ -19,27 +19,27 @@ The core routines for the subroutine interface are:
 
 !f(x)
 subroutine db1ink(x,nx,fcn,kx,iknot,tx,bcoef,iflag)
-subroutine db1val(xval,idx,tx,nx,kx,bcoef,f,iflag,inbvx,extrap)
+subroutine db1val(xval,idx,tx,nx,kx,bcoef,f,iflag,inbvx,w0,extrap)
 
 !f(x,y)
 subroutine db2ink(x,nx,y,ny,fcn,kx,ky,iknot,tx,ty,bcoef,iflag)
-subroutine db2val(xval,yval,idx,idy,tx,ty,nx,ny,kx,ky,bcoef,f,iflag,inbvx,inbvy,iloy,extrap)
+subroutine db2val(xval,yval,idx,idy,tx,ty,nx,ny,kx,ky,bcoef,f,iflag,inbvx,inbvy,iloy,w1,w0,extrap)
 
 !f(x,y,z)
 subroutine db3ink(x,nx,y,ny,z,nz,fcn,kx,ky,kz,iknot,tx,ty,tz,bcoef,iflag)
-subroutine db3val(xval,yval,zval,idx,idy,idz,tx,ty,tz,nx,ny,nz,kx,ky,kz,bcoef,f,iflag,inbvx,inbvy,inbvz,iloy,iloz,extrap)
+subroutine db3val(xval,yval,zval,idx,idy,idz,tx,ty,tz,nx,ny,nz,kx,ky,kz,bcoef,f,iflag,inbvx,inbvy,inbvz,iloy,iloz,w2,w1,w0,extrap)
 
 !f(x,y,z,q)
 subroutine db4ink(x,nx,y,ny,z,nz,q,nq,fcn,kx,ky,kz,kq,iknot,tx,ty,tz,tq,bcoef,iflag)
-subroutine db4val(xval,yval,zval,qval,idx,idy,idz,idq,tx,ty,tz,tq,nx,ny,nz,nq,kx,ky,kz,kq,bcoef,f,iflag,inbvx,inbvy,inbvz,inbvq,iloy,iloz,iloq,extrap)
+subroutine db4val(xval,yval,zval,qval,idx,idy,idz,idq,tx,ty,tz,tq,nx,ny,nz,nq,kx,ky,kz,kq,bcoef,f,iflag,inbvx,inbvy,inbvz,inbvq,iloy,iloz,iloq,w3,w2,w1,w0,extrap)
 
 !f(x,y,z,q,r)
 subroutine db5ink(x,nx,y,ny,z,nz,q,nq,r,nr,fcn,kx,ky,kz,kq,kr,iknot,tx,ty,tz,tq,tr,bcoef,iflag)
-subroutine db5val(xval,yval,zval,qval,rval,idx,idy,idz,idq,idr,tx,ty,tz,tq,tr,nx,ny,nz,nq,nr,kx,ky,kz,kq,kr,bcoef,f,iflag,inbvx,inbvy,inbvz,inbvq,inbvr,iloy,iloz,iloq,ilor,extrap)
+subroutine db5val(xval,yval,zval,qval,rval,idx,idy,idz,idq,idr,tx,ty,tz,tq,tr,nx,ny,nz,nq,nr,kx,ky,kz,kq,kr,bcoef,f,iflag,inbvx,inbvy,inbvz,inbvq,inbvr,iloy,iloz,iloq,ilor,w4,w3,w2,w1,w0,extrap)
 
 !f(x,y,z,q,r,s)
 subroutine db6ink(x,nx,y,ny,z,nz,q,nq,r,nr,s,ns,fcn,kx,ky,kz,kq,kr,ks,iknot,tx,ty,tz,tq,tr,ts,bcoef,iflag)
-subroutine db6val(xval,yval,zval,qval,rval,sval,idx,idy,idz,idq,idr,ids,tx,ty,tz,tq,tr,ts,nx,ny,nz,nq,nr,ns,kx,ky,kz,kq,kr,ks,bcoef,f,iflag,inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos,extrap)
+subroutine db6val(xval,yval,zval,qval,rval,sval,idx,idy,idz,idq,idr,ids,tx,ty,tz,tq,tr,ts,nx,ny,nz,nq,nr,ns,kx,ky,kz,kq,kr,ks,bcoef,f,iflag,inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos,w5,w3,w2,w1,w0,extrap)
 ```
 
 The ```ink``` routines compute the interpolant coefficients, and the ```val``` routines evalute the interpolant at the specified value of each coordinate. The 2D and 3D routines are extensively refactored versions of the original routines from the [NIST Core Math Library](http://www.nist.gov/itl/math/mcsd-software.cfm).  The others are new, and are simply extensions of the same algorithm into the other dimensions.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See the [examples](https://github.com/jacobwilliams/bspline-fortran/tree/master/
 
 # Compiling
 
-A simple bash script ```build.sh``` is provided for building bspline-fortran with gfortran using [FoBiS](https://github.com/szaghi/FoBiS). It also builds the API documentation using [FORD](https://github.com/cmacmackin/ford). The library can also be compiled with the Intel Fortran Compiler (and presumably any other Fortran compiler that supports modern standards).
+A simple bash script ```build.sh``` is provided for building bspline-fortran with gfortran using [FoBiS](https://github.com/szaghi/FoBiS). It also builds the API documentation using [FORD](https://github.com/Fortran-FOSS-Programmers/ford). The library can also be compiled with the Intel Fortran Compiler (and presumably any other Fortran compiler that supports modern standards).
 
 A basic CMake configuration file is also included. For example, to build a static library:
 

--- a/src/bspline_kinds_module.f90
+++ b/src/bspline_kinds_module.f90
@@ -13,7 +13,8 @@
 
     private
 
-    integer,parameter,public :: wp = real64  !! Real precision
+    integer,parameter,public :: wp = real64  !! Real working precision
+    integer,parameter,public :: ip = int32   !! Integer working precision
 
 !*****************************************************************************************
     end module bspline_kinds_module

--- a/src/bspline_oo_module.f90
+++ b/src/bspline_oo_module.f90
@@ -70,6 +70,7 @@
         integer :: kx  = 0  !! The order of spline pieces in \(x\)
         real(wp),dimension(:),allocatable :: bcoef  !! array of coefficients of the b-spline interpolant
         real(wp),dimension(:),allocatable :: tx  !! The knots in the \(x\) direction for the spline interpolant
+        real(wp),dimension(:),allocatable :: work_val_1   !! [[db1val] work array of dimension `3*kx`
         contains
         private
         generic,public :: initialize => initialize_1d_auto_knots,initialize_1d_specify_knots
@@ -95,6 +96,8 @@
         real(wp),dimension(:),allocatable :: ty  !! The knots in the \(y\) direction for the spline interpolant
         integer :: inbvy = 1  !! internal variable used for efficient processing
         integer :: iloy = 1  !! internal variable used for efficient processing
+        real(wp),dimension(:),allocatable :: work_val_1  !! [[db2val] work array of dimension `ky`
+        real(wp),dimension(:),allocatable :: work_val_2  !! [[db2val] work array of dimension `3*max(kx,ky)`
         contains
         private
         generic,public :: initialize => initialize_2d_auto_knots,initialize_2d_specify_knots
@@ -123,6 +126,9 @@
         integer :: inbvz = 1  !! internal variable used for efficient processing
         integer :: iloy = 1  !! internal variable used for efficient processing
         integer :: iloz = 1  !! internal variable used for efficient processing
+        real(wp),dimension(:,:),allocatable :: work_val_1  !! [[db3val] work array of dimension `ky,kz`
+        real(wp),dimension(:),allocatable   :: work_val_2  !! [[db3val] work array of dimension `kz`
+        real(wp),dimension(:),allocatable   :: work_val_3  !! [[db3val] work array of dimension `3*max(kx,ky,kz)`
         contains
         private
         generic,public :: initialize => initialize_3d_auto_knots,initialize_3d_specify_knots
@@ -156,6 +162,10 @@
         integer :: iloy  = 1  !! internal variable used for efficient processing
         integer :: iloz  = 1  !! internal variable used for efficient processing
         integer :: iloq  = 1  !! internal variable used for efficient processing
+        real(wp),dimension(:,:,:),allocatable :: work_val_1  !! [[db4val]] work array of dimension `ky,kz,kq`
+        real(wp),dimension(:,:),allocatable   :: work_val_2  !! [[db4val]] work array of dimension `kz,kq`
+        real(wp),dimension(:),allocatable     :: work_val_3  !! [[db4val]] work array of dimension `kq`
+        real(wp),dimension(:),allocatable     :: work_val_4  !! [[db4val]] work array of dimension `3*max(kx,ky,kz,kq)`
         contains
         private
         generic,public :: initialize => initialize_4d_auto_knots,initialize_4d_specify_knots
@@ -194,6 +204,11 @@
         integer :: iloz  = 1  !! internal variable used for efficient processing
         integer :: iloq  = 1  !! internal variable used for efficient processing
         integer :: ilor  = 1  !! internal variable used for efficient processing
+        real(wp),dimension(:,:,:,:),allocatable :: work_val_1  !! [[db5val]] work array of dimension `ky,kz,kq,kr`
+        real(wp),dimension(:,:,:),allocatable   :: work_val_2  !! [[db5val]] work array of dimension `kz,kq,kr`
+        real(wp),dimension(:,:),allocatable     :: work_val_3  !! [[db5val]] work array of dimension `kq,kr`
+        real(wp),dimension(:),allocatable       :: work_val_4  !! [[db5val]] work array of dimension `kr`
+        real(wp),dimension(:),allocatable       :: work_val_5  !! [[db5val]] work array of dimension `3*max(kx,ky,kz,kq,kr)`
         contains
         private
         generic,public :: initialize => initialize_5d_auto_knots,initialize_5d_specify_knots
@@ -237,6 +252,12 @@
         integer :: iloq  = 1  !! internal variable used for efficient processing
         integer :: ilor  = 1  !! internal variable used for efficient processing
         integer :: ilos  = 1  !! internal variable used for efficient processing
+        real(wp),dimension(:,:,:,:,:),allocatable :: work_val_1  !! [[db6val]] work array of dimension `ky,kz,kq,kr,ks`
+        real(wp),dimension(:,:,:,:),allocatable   :: work_val_2  !! [[db6val]] work array of dimension `kz,kq,kr,ks`
+        real(wp),dimension(:,:,:),allocatable     :: work_val_3  !! [[db6val]] work array of dimension `kq,kr,ks`
+        real(wp),dimension(:,:),allocatable       :: work_val_4  !! [[db6val]] work array of dimension `kr,ks`
+        real(wp),dimension(:),allocatable         :: work_val_5  !! [[db6val]] work array of dimension `ks`
+        real(wp),dimension(:),allocatable         :: work_val_6  !! [[db6val]] work array of dimension `3*max(kx,ky,kz,kq,kr,ks)`
         contains
         private
         generic,public :: initialize => initialize_6d_auto_knots,initialize_6d_specify_knots
@@ -375,8 +396,9 @@
 
     s = 2*int_size + logical_size + 2*int_size
 
-    if (allocated(me%bcoef)) s = s + real_size*size(me%bcoef)
-    if (allocated(me%tx))    s = s + real_size*size(me%tx)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1)
 
     end function size_1d
 !*****************************************************************************************
@@ -394,10 +416,12 @@
 
     s = 2*int_size + logical_size + 6*int_size
 
-    if (allocated(me%bcoef)) s = s + real_size*size(me%bcoef,1)*&
-                                               size(me%bcoef,2)
-    if (allocated(me%tx)) s = s + real_size*size(me%tx)
-    if (allocated(me%ty)) s = s + real_size*size(me%ty)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1)*&
+                                                    size(me%bcoef,2)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx)
+    if (allocated(me%ty))         s = s + real_size*size(me%ty)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1)
+    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2)
 
     end function size_2d
 !*****************************************************************************************
@@ -415,12 +439,16 @@
 
     s = 2*int_size + logical_size + 10*int_size
 
-    if (allocated(me%bcoef)) s = s + real_size*size(me%bcoef,1)*&
-                                               size(me%bcoef,2)*&
-                                               size(me%bcoef,3)
-    if (allocated(me%tx)) s = s + real_size*size(me%tx)
-    if (allocated(me%ty)) s = s + real_size*size(me%ty)
-    if (allocated(me%tz)) s = s + real_size*size(me%tz)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1)*&
+                                                    size(me%bcoef,2)*&
+                                                    size(me%bcoef,3)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx)
+    if (allocated(me%ty))         s = s + real_size*size(me%ty)
+    if (allocated(me%tz))         s = s + real_size*size(me%tz)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1)*&
+                                                    size(me%work_val_1,2)
+    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2)
+    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3)
 
     end function size_3d
 !*****************************************************************************************
@@ -438,14 +466,21 @@
 
     s = 2*int_size + logical_size + 14*int_size
 
-    if (allocated(me%bcoef)) s = s + real_size*size(me%bcoef,1)*&
-                                               size(me%bcoef,2)*&
-                                               size(me%bcoef,3)*&
-                                               size(me%bcoef,4)
-    if (allocated(me%tx)) s = s + real_size*size(me%tx)
-    if (allocated(me%ty)) s = s + real_size*size(me%ty)
-    if (allocated(me%tz)) s = s + real_size*size(me%tz)
-    if (allocated(me%tq)) s = s + real_size*size(me%tq)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1)*&
+                                                    size(me%bcoef,2)*&
+                                                    size(me%bcoef,3)*&
+                                                    size(me%bcoef,4)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx)
+    if (allocated(me%ty))         s = s + real_size*size(me%ty)
+    if (allocated(me%tz))         s = s + real_size*size(me%tz)
+    if (allocated(me%tq))         s = s + real_size*size(me%tq)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1)*&
+                                                    size(me%work_val_1,2)*&
+                                                    size(me%work_val_1,3)
+    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,1)*&
+                                                    size(me%work_val_2,2)
+    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3)
+    if (allocated(me%work_val_4)) s = s + real_size*size(me%work_val_4)
 
     end function size_4d
 !*****************************************************************************************
@@ -463,16 +498,27 @@
 
     s = 2*int_size + logical_size + 18*int_size
 
-    if (allocated(me%bcoef)) s = s + real_size*size(me%bcoef,1)*&
-                                               size(me%bcoef,2)*&
-                                               size(me%bcoef,3)*&
-                                               size(me%bcoef,4)*&
-                                               size(me%bcoef,5)
-    if (allocated(me%tx)) s = s + real_size*size(me%tx)
-    if (allocated(me%ty)) s = s + real_size*size(me%ty)
-    if (allocated(me%tz)) s = s + real_size*size(me%tz)
-    if (allocated(me%tq)) s = s + real_size*size(me%tq)
-    if (allocated(me%tr)) s = s + real_size*size(me%tr)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1)*&
+                                                    size(me%bcoef,2)*&
+                                                    size(me%bcoef,3)*&
+                                                    size(me%bcoef,4)*&
+                                                    size(me%bcoef,5)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx)
+    if (allocated(me%ty))         s = s + real_size*size(me%ty)
+    if (allocated(me%tz))         s = s + real_size*size(me%tz)
+    if (allocated(me%tq))         s = s + real_size*size(me%tq)
+    if (allocated(me%tr))         s = s + real_size*size(me%tr)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1)*&
+                                                    size(me%work_val_1,2)*&
+                                                    size(me%work_val_1,3)*&
+                                                    size(me%work_val_1,4)
+    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,1)*&
+                                                    size(me%work_val_2,2)*&
+                                                    size(me%work_val_2,3)
+    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3,1)*&
+                                                    size(me%work_val_3,2)
+    if (allocated(me%work_val_4)) s = s + real_size*size(me%work_val_4)
+    if (allocated(me%work_val_5)) s = s + real_size*size(me%work_val_5)
 
     end function size_5d
 !*****************************************************************************************
@@ -490,18 +536,34 @@
 
     s = 2*int_size + logical_size + 22*int_size
 
-    if (allocated(me%bcoef)) s = s + real_size*size(me%bcoef,1)*&
-                                               size(me%bcoef,2)*&
-                                               size(me%bcoef,3)*&
-                                               size(me%bcoef,4)*&
-                                               size(me%bcoef,5)*&
-                                               size(me%bcoef,6)
-    if (allocated(me%tx)) s = s + real_size*size(me%tx)
-    if (allocated(me%ty)) s = s + real_size*size(me%ty)
-    if (allocated(me%tz)) s = s + real_size*size(me%tz)
-    if (allocated(me%tq)) s = s + real_size*size(me%tq)
-    if (allocated(me%tr)) s = s + real_size*size(me%tr)
-    if (allocated(me%ts)) s = s + real_size*size(me%ts)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1)*&
+                                                    size(me%bcoef,2)*&
+                                                    size(me%bcoef,3)*&
+                                                    size(me%bcoef,4)*&
+                                                    size(me%bcoef,5)*&
+                                                    size(me%bcoef,6)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx)
+    if (allocated(me%ty))         s = s + real_size*size(me%ty)
+    if (allocated(me%tz))         s = s + real_size*size(me%tz)
+    if (allocated(me%tq))         s = s + real_size*size(me%tq)
+    if (allocated(me%tr))         s = s + real_size*size(me%tr)
+    if (allocated(me%ts))         s = s + real_size*size(me%ts)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1)*&
+                                                    size(me%work_val_1,2)*&
+                                                    size(me%work_val_1,3)*&
+                                                    size(me%work_val_1,4)*&
+                                                    size(me%work_val_1,5)
+    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,1)*&
+                                                    size(me%work_val_2,2)*&
+                                                    size(me%work_val_2,3)*&
+                                                    size(me%work_val_2,4)
+    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3,1)*&
+                                                    size(me%work_val_3,2)*&
+                                                    size(me%work_val_3,3)
+    if (allocated(me%work_val_4)) s = s + real_size*size(me%work_val_4,1)*&
+                                                    size(me%work_val_4,2)
+    if (allocated(me%work_val_5)) s = s + real_size*size(me%work_val_5)
+    if (allocated(me%work_val_6)) s = s + real_size*size(me%work_val_6)
 
     end function size_6d
 !*****************************************************************************************
@@ -539,8 +601,9 @@
 
     me%nx  = 0
     me%kx  = 0
-    if (allocated(me%bcoef))    deallocate(me%bcoef)
-    if (allocated(me%tx))       deallocate(me%tx)
+    if (allocated(me%bcoef))      deallocate(me%bcoef)
+    if (allocated(me%tx))         deallocate(me%tx)
+    if (allocated(me%work_val_1)) deallocate(me%work_val_1)
 
     end subroutine destroy_1d
 !*****************************************************************************************
@@ -563,9 +626,11 @@
     me%ky    = 0
     me%inbvy = 1
     me%iloy  = 1
-    if (allocated(me%bcoef))    deallocate(me%bcoef)
-    if (allocated(me%tx))       deallocate(me%tx)
-    if (allocated(me%ty))       deallocate(me%ty)
+    if (allocated(me%bcoef))      deallocate(me%bcoef)
+    if (allocated(me%tx))         deallocate(me%tx)
+    if (allocated(me%ty))         deallocate(me%ty)
+    if (allocated(me%work_val_1)) deallocate(me%work_val_1)
+    if (allocated(me%work_val_2)) deallocate(me%work_val_2)
 
     end subroutine destroy_2d
 !*****************************************************************************************
@@ -592,10 +657,13 @@
     me%inbvz = 1
     me%iloy  = 1
     me%iloz  = 1
-    if (allocated(me%bcoef))    deallocate(me%bcoef)
-    if (allocated(me%tx))       deallocate(me%tx)
-    if (allocated(me%ty))       deallocate(me%ty)
-    if (allocated(me%tz))       deallocate(me%tz)
+    if (allocated(me%bcoef))      deallocate(me%bcoef)
+    if (allocated(me%tx))         deallocate(me%tx)
+    if (allocated(me%ty))         deallocate(me%ty)
+    if (allocated(me%tz))         deallocate(me%tz)
+    if (allocated(me%work_val_1)) deallocate(me%work_val_1)
+    if (allocated(me%work_val_2)) deallocate(me%work_val_2)
+    if (allocated(me%work_val_3)) deallocate(me%work_val_3)
 
     end subroutine destroy_3d
 !*****************************************************************************************
@@ -624,11 +692,15 @@
     me%iloy  = 1
     me%iloz  = 1
     me%iloq  = 1
-    if (allocated(me%bcoef))   deallocate(me%bcoef)
-    if (allocated(me%tx))      deallocate(me%tx)
-    if (allocated(me%ty))      deallocate(me%ty)
-    if (allocated(me%tz))      deallocate(me%tz)
-    if (allocated(me%tq))      deallocate(me%tq)
+    if (allocated(me%bcoef))      deallocate(me%bcoef)
+    if (allocated(me%tx))         deallocate(me%tx)
+    if (allocated(me%ty))         deallocate(me%ty)
+    if (allocated(me%tz))         deallocate(me%tz)
+    if (allocated(me%tq))         deallocate(me%tq)
+    if (allocated(me%work_val_1)) deallocate(me%work_val_1)
+    if (allocated(me%work_val_2)) deallocate(me%work_val_2)
+    if (allocated(me%work_val_3)) deallocate(me%work_val_3)
+    if (allocated(me%work_val_4)) deallocate(me%work_val_4)
 
     end subroutine destroy_4d
 !*****************************************************************************************
@@ -661,12 +733,17 @@
     me%iloz  = 1
     me%iloq  = 1
     me%ilor  = 1
-    if (allocated(me%bcoef))    deallocate(me%bcoef)
-    if (allocated(me%tx))       deallocate(me%tx)
-    if (allocated(me%ty))       deallocate(me%ty)
-    if (allocated(me%tz))       deallocate(me%tz)
-    if (allocated(me%tq))       deallocate(me%tq)
-    if (allocated(me%tr))       deallocate(me%tr)
+    if (allocated(me%bcoef))      deallocate(me%bcoef)
+    if (allocated(me%tx))         deallocate(me%tx)
+    if (allocated(me%ty))         deallocate(me%ty)
+    if (allocated(me%tz))         deallocate(me%tz)
+    if (allocated(me%tq))         deallocate(me%tq)
+    if (allocated(me%tr))         deallocate(me%tr)
+    if (allocated(me%work_val_1)) deallocate(me%work_val_1)
+    if (allocated(me%work_val_2)) deallocate(me%work_val_2)
+    if (allocated(me%work_val_3)) deallocate(me%work_val_3)
+    if (allocated(me%work_val_4)) deallocate(me%work_val_4)
+    if (allocated(me%work_val_5)) deallocate(me%work_val_5)
 
     end subroutine destroy_5d
 !*****************************************************************************************
@@ -703,13 +780,19 @@
     me%iloq  = 1
     me%ilor  = 1
     me%ilos  = 1
-    if (allocated(me%bcoef))    deallocate(me%bcoef)
-    if (allocated(me%tx))       deallocate(me%tx)
-    if (allocated(me%ty))       deallocate(me%ty)
-    if (allocated(me%tz))       deallocate(me%tz)
-    if (allocated(me%tq))       deallocate(me%tq)
-    if (allocated(me%tr))       deallocate(me%tr)
-    if (allocated(me%ts))       deallocate(me%ts)
+    if (allocated(me%bcoef))      deallocate(me%bcoef)
+    if (allocated(me%tx))         deallocate(me%tx)
+    if (allocated(me%ty))         deallocate(me%ty)
+    if (allocated(me%tz))         deallocate(me%tz)
+    if (allocated(me%tq))         deallocate(me%tq)
+    if (allocated(me%tr))         deallocate(me%tr)
+    if (allocated(me%ts))         deallocate(me%ts)
+    if (allocated(me%work_val_1)) deallocate(me%work_val_1)
+    if (allocated(me%work_val_2)) deallocate(me%work_val_2)
+    if (allocated(me%work_val_3)) deallocate(me%work_val_3)
+    if (allocated(me%work_val_4)) deallocate(me%work_val_4)
+    if (allocated(me%work_val_5)) deallocate(me%work_val_5)
+    if (allocated(me%work_val_6)) deallocate(me%work_val_6)
 
     end subroutine destroy_6d
 !*****************************************************************************************
@@ -875,6 +958,7 @@
 
     allocate(me%tx(nx+kx))
     allocate(me%bcoef(nx))
+    allocate(me%work_val_1(3*kx))
 
     iknot = 0         !knot sequence chosen by db1ink
 
@@ -928,6 +1012,7 @@
 
         allocate(me%tx(nx+kx))
         allocate(me%bcoef(nx))
+        allocate(me%work_val_1(3*kx))
 
         me%tx = tx
 
@@ -958,7 +1043,8 @@
     integer,intent(out)             :: iflag !! status flag (see [[db1val]])
 
     if (me%initialized) then
-        call db1val(xval,idx,me%tx,me%nx,me%kx,me%bcoef,f,iflag,me%inbvx,me%extrap)
+        call db1val(xval,idx,me%tx,me%nx,me%kx,me%bcoef,f,iflag,&
+                    me%inbvx,me%work_val_1,extrap=me%extrap)
     else
         iflag = 1
     end if
@@ -982,7 +1068,7 @@
     integer,intent(out)             :: iflag !! status flag (see [[db1sqad]])
 
     if (me%initialized) then
-        call db1sqad(me%tx,me%bcoef,me%nx,me%kx,x1,x2,f,iflag)
+        call db1sqad(me%tx,me%bcoef,me%nx,me%kx,x1,x2,f,iflag,me%work_val_1)
     else
         iflag = 1
     end if
@@ -1011,7 +1097,7 @@
     integer,intent(out)             :: iflag !! status flag (see [[db1sqad]])
 
     if (me%initialized) then
-        call db1fqad(fun,me%tx,me%bcoef,me%nx,me%kx,idx,x1,x2,tol,f,iflag)
+        call db1fqad(fun,me%tx,me%bcoef,me%nx,me%kx,idx,x1,x2,tol,f,iflag,me%work_val_1)
     else
         iflag = 1
     end if
@@ -1141,6 +1227,8 @@
     allocate(me%tx(nx+kx))
     allocate(me%ty(ny+ky))
     allocate(me%bcoef(nx,ny))
+    allocate(me%work_val_1(ky))
+    allocate(me%work_val_2(3*max(kx,ky)))
 
     iknot = 0         !knot sequence chosen by db2ink
 
@@ -1209,6 +1297,8 @@
         allocate(me%tx(nx+kx))
         allocate(me%ty(ny+ky))
         allocate(me%bcoef(nx,ny))
+        allocate(me%work_val_1(ky))
+        allocate(me%work_val_2(3*max(kx,ky)))
 
         me%tx = tx
         me%ty = ty
@@ -1249,7 +1339,8 @@
                     me%kx,me%ky,&
                     me%bcoef,f,iflag,&
                     me%inbvx,me%inbvy,me%iloy,&
-                    me%extrap)
+                    me%work_val_1,me%work_val_2,&
+                    extrap=me%extrap)
     else
         iflag = 1
     end if
@@ -1399,6 +1490,9 @@
     allocate(me%ty(ny+ky))
     allocate(me%tz(nz+kz))
     allocate(me%bcoef(nx,ny,nz))
+    allocate(me%work_val_1(ky,kz))
+    allocate(me%work_val_2(kz))
+    allocate(me%work_val_3(3*max(kx,ky,kz)))
 
     iknot = 0         !knot sequence chosen by db3ink
 
@@ -1484,6 +1578,9 @@
         allocate(me%ty(ny+ky))
         allocate(me%tz(nz+kz))
         allocate(me%bcoef(nx,ny,nz))
+        allocate(me%work_val_1(ky,kz))
+        allocate(me%work_val_2(kz))
+        allocate(me%work_val_3(3*max(kx,ky,kz)))
 
         me%tx = tx
         me%ty = ty
@@ -1533,7 +1630,8 @@
                     me%bcoef,f,iflag,&
                     me%inbvx,me%inbvy,me%inbvz,&
                     me%iloy,me%iloz,&
-                    me%extrap)
+                    me%work_val_1,me%work_val_2,me%work_val_3,&
+                    extrap=me%extrap)
     else
         iflag = 1
     end if
@@ -1703,6 +1801,10 @@
     allocate(me%tz(nz+kz))
     allocate(me%tq(nq+kq))
     allocate(me%bcoef(nx,ny,nz,nq))
+    allocate(me%work_val_1(ky,kz,kq))
+    allocate(me%work_val_2(kz,kq))
+    allocate(me%work_val_3(kq))
+    allocate(me%work_val_4(3*max(kx,ky,kz,kq)))
 
     iknot = 0         !knot sequence chosen by db4ink
 
@@ -1801,6 +1903,10 @@
         allocate(me%tz(nz+kz))
         allocate(me%tq(nq+kq))
         allocate(me%bcoef(nx,ny,nz,nq))
+        allocate(me%work_val_1(ky,kz,kq))
+        allocate(me%work_val_2(kz,kq))
+        allocate(me%work_val_3(kq))
+        allocate(me%work_val_4(3*max(kx,ky,kz,kq)))
 
         me%tx = tx
         me%ty = ty
@@ -1853,7 +1959,8 @@
                     me%bcoef,f,iflag,&
                     me%inbvx,me%inbvy,me%inbvz,me%inbvq,&
                     me%iloy,me%iloz,me%iloq,&
-                    me%extrap)
+                    me%work_val_1,me%work_val_2,me%work_val_3,me%work_val_4,&
+                    extrap=me%extrap)
     else
         iflag = 1
     end if
@@ -2043,6 +2150,11 @@
     allocate(me%tq(nq+kq))
     allocate(me%tr(nr+kr))
     allocate(me%bcoef(nx,ny,nz,nq,nr))
+    allocate(me%work_val_1(ky,kz,kq,kr))
+    allocate(me%work_val_2(kz,kq,kr))
+    allocate(me%work_val_3(kq,kr))
+    allocate(me%work_val_4(kr))
+    allocate(me%work_val_5(3*max(kx,ky,kz,kq,kr)))
 
     iknot = 0         !knot sequence chosen by db5ink
 
@@ -2154,6 +2266,11 @@
         allocate(me%tq(nq+kq))
         allocate(me%tr(nr+kr))
         allocate(me%bcoef(nx,ny,nz,nq,nr))
+        allocate(me%work_val_1(ky,kz,kq,kr))
+        allocate(me%work_val_2(kz,kq,kr))
+        allocate(me%work_val_3(kq,kr))
+        allocate(me%work_val_4(kr))
+        allocate(me%work_val_5(3*max(kx,ky,kz,kq,kr)))
 
         me%tx = tx
         me%ty = ty
@@ -2209,7 +2326,8 @@
                     me%bcoef,f,iflag,&
                     me%inbvx,me%inbvy,me%inbvz,me%inbvq,me%inbvr,&
                     me%iloy,me%iloz,me%iloq,me%ilor,&
-                    me%extrap)
+                    me%work_val_1,me%work_val_2,me%work_val_3,me%work_val_4,me%work_val_5,&
+                    extrap=me%extrap)
     else
         iflag = 1
     end if
@@ -2422,6 +2540,12 @@
     allocate(me%tr(nr+kr))
     allocate(me%ts(ns+ks))
     allocate(me%bcoef(nx,ny,nz,nq,nr,ns))
+    allocate(me%work_val_1(ky,kz,kq,kr,ks))
+    allocate(me%work_val_2(kz,kq,kr,ks))
+    allocate(me%work_val_3(kq,kr,ks))
+    allocate(me%work_val_4(kr,ks))
+    allocate(me%work_val_5(ks))
+    allocate(me%work_val_6(3*max(kx,ky,kz,kq,kr,ks)))
 
     iknot = 0         !knot sequence chosen by db6ink
 
@@ -2545,6 +2669,12 @@
         allocate(me%tr(nr+kr))
         allocate(me%ts(ns+ks))
         allocate(me%bcoef(nx,ny,nz,nq,nr,ns))
+        allocate(me%work_val_1(ky,kz,kq,kr,ks))
+        allocate(me%work_val_2(kz,kq,kr,ks))
+        allocate(me%work_val_3(kq,kr,ks))
+        allocate(me%work_val_4(kr,ks))
+        allocate(me%work_val_5(ks))
+        allocate(me%work_val_6(3*max(kx,ky,kz,kq,kr,ks)))
 
         me%tx = tx
         me%ty = ty
@@ -2603,7 +2733,8 @@
                     me%bcoef,f,iflag,&
                     me%inbvx,me%inbvy,me%inbvz,me%inbvq,me%inbvr,me%inbvs,&
                     me%iloy,me%iloz,me%iloq,me%ilor,me%ilos,&
-                    me%extrap)
+                    me%work_val_1,me%work_val_2,me%work_val_3,me%work_val_4,me%work_val_5,me%work_val_6,&
+                    extrap=me%extrap)
     else
         iflag = 1
     end if

--- a/src/bspline_oo_module.f90
+++ b/src/bspline_oo_module.f90
@@ -10,7 +10,7 @@
 
     module bspline_oo_module
 
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
     use,intrinsic :: iso_fortran_env, only: error_unit
     use bspline_sub_module
 
@@ -18,15 +18,15 @@
 
     private
 
-    integer,parameter :: int_size     = storage_size(1)       !! size of a default integer [bits]
-    integer,parameter :: logical_size = storage_size(.true.)  !! size of a default logical [bits]
-    integer,parameter :: real_size    = storage_size(1.0_wp)  !! size of a `real(wp)` [bits]
+    integer(ip),parameter :: int_size     = storage_size(1_ip,kind=ip)   !! size of a default integer [bits]
+    integer(ip),parameter :: logical_size = storage_size(.true.,kind=ip) !! size of a default logical [bits]
+    integer(ip),parameter :: real_size    = storage_size(1.0_wp,kind=ip) !! size of a `real(wp)` [bits]
 
     type,public,abstract :: bspline_class
         !! Base class for the b-spline types
         private
-        integer :: inbvx = 1  !! internal variable used by [[dbvalu]] for efficient processing
-        integer :: iflag = 1  !! saved `iflag` from the list routine call.
+        integer(ip) :: inbvx = 1_ip  !! internal variable used by [[dbvalu]] for efficient processing
+        integer(ip) :: iflag = 1_ip  !! saved `iflag` from the list routine call.
         logical :: initialized = .false. !! true if the class is initialized and ready to use
         logical :: extrap = .false. !! if true, then extrapolation is allowed during evaluation
     contains
@@ -52,10 +52,10 @@
 
         pure function size_func(me) result(s)
         !! interface for size routines
-        import :: bspline_class
+        import :: bspline_class,ip
         implicit none
         class(bspline_class),intent(in) :: me
-        integer :: s !! size of the structure in bits
+        integer(ip) :: s !! size of the structure in bits
         end function size_func
 
     end interface
@@ -66,8 +66,8 @@
         !!@note The 1D class also contains two methods
         !!      for computing definite integrals.
         private
-        integer :: nx  = 0  !! Number of \(x\) abcissae
-        integer :: kx  = 0  !! The order of spline pieces in \(x\)
+        integer(ip) :: nx = 0_ip  !! Number of \(x\) abcissae
+        integer(ip) :: kx = 0_ip  !! The order of spline pieces in \(x\)
         real(wp),dimension(:),allocatable :: bcoef  !! array of coefficients of the b-spline interpolant
         real(wp),dimension(:),allocatable :: tx  !! The knots in the \(x\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: work_val_1   !! [[db1val] work array of dimension `3*kx`
@@ -87,17 +87,17 @@
     type,extends(bspline_class),public :: bspline_2d
         !! Class for 2d b-spline interpolation.
         private
-        integer :: nx  = 0  !! Number of \(x\) abcissae
-        integer :: ny  = 0  !! Number of \(y\) abcissae
-        integer :: kx  = 0  !! The order of spline pieces in \(x\)
-        integer :: ky  = 0  !! The order of spline pieces in \(y\)
+        integer(ip) :: nx = 0_ip  !! Number of \(x\) abcissae
+        integer(ip) :: ny = 0_ip  !! Number of \(y\) abcissae
+        integer(ip) :: kx = 0_ip  !! The order of spline pieces in \(x\)
+        integer(ip) :: ky = 0_ip  !! The order of spline pieces in \(y\)
         real(wp),dimension(:,:),allocatable :: bcoef  !! array of coefficients of the b-spline interpolant
         real(wp),dimension(:),allocatable :: tx  !! The knots in the \(x\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: ty  !! The knots in the \(y\) direction for the spline interpolant
-        integer :: inbvy = 1  !! internal variable used for efficient processing
-        integer :: iloy = 1  !! internal variable used for efficient processing
+        integer(ip) :: inbvy = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloy = 1_ip  !! internal variable used for efficient processing
         real(wp),dimension(:),allocatable :: work_val_1  !! [[db2val] work array of dimension `ky`
-        real(wp),dimension(:),allocatable :: work_val_2  !! [[db2val] work array of dimension `3*max(kx,ky)`
+        real(wp),dimension(:),allocatable :: work_val_2  !! [[db2val] work array of dimension `3_ip*max(kx,ky)`
         contains
         private
         generic,public :: initialize => initialize_2d_auto_knots,initialize_2d_specify_knots
@@ -112,23 +112,23 @@
     type,extends(bspline_class),public :: bspline_3d
         !! Class for 3d b-spline interpolation.
         private
-        integer :: nx  = 0  !! Number of \(x\) abcissae
-        integer :: ny  = 0  !! Number of \(y\) abcissae
-        integer :: nz  = 0  !! Number of \(z\) abcissae
-        integer :: kx  = 0  !! The order of spline pieces in \(x\)
-        integer :: ky  = 0  !! The order of spline pieces in \(y\)
-        integer :: kz  = 0  !! The order of spline pieces in \(z\)
+        integer(ip) :: nx = 0_ip  !! Number of \(x\) abcissae
+        integer(ip) :: ny = 0_ip  !! Number of \(y\) abcissae
+        integer(ip) :: nz = 0_ip  !! Number of \(z\) abcissae
+        integer(ip) :: kx = 0_ip  !! The order of spline pieces in \(x\)
+        integer(ip) :: ky = 0_ip  !! The order of spline pieces in \(y\)
+        integer(ip) :: kz = 0_ip  !! The order of spline pieces in \(z\)
         real(wp),dimension(:,:,:),allocatable :: bcoef  !! array of coefficients of the b-spline interpolant
         real(wp),dimension(:),allocatable :: tx  !! The knots in the \(x\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: ty  !! The knots in the \(y\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: tz  !! The knots in the \(z\) direction for the spline interpolant
-        integer :: inbvy = 1  !! internal variable used for efficient processing
-        integer :: inbvz = 1  !! internal variable used for efficient processing
-        integer :: iloy = 1  !! internal variable used for efficient processing
-        integer :: iloz = 1  !! internal variable used for efficient processing
+        integer(ip) :: inbvy = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: inbvz = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloy = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloz = 1_ip  !! internal variable used for efficient processing
         real(wp),dimension(:,:),allocatable :: work_val_1  !! [[db3val] work array of dimension `ky,kz`
         real(wp),dimension(:),allocatable   :: work_val_2  !! [[db3val] work array of dimension `kz`
-        real(wp),dimension(:),allocatable   :: work_val_3  !! [[db3val] work array of dimension `3*max(kx,ky,kz)`
+        real(wp),dimension(:),allocatable   :: work_val_3  !! [[db3val] work array of dimension `3_ip*max(kx,ky,kz)`
         contains
         private
         generic,public :: initialize => initialize_3d_auto_knots,initialize_3d_specify_knots
@@ -143,29 +143,29 @@
     type,extends(bspline_class),public :: bspline_4d
         !! Class for 4d b-spline interpolation.
         private
-        integer :: nx  = 0  !! Number of \(x\) abcissae
-        integer :: ny  = 0  !! Number of \(y\) abcissae
-        integer :: nz  = 0  !! Number of \(z\) abcissae
-        integer :: nq  = 0  !! Number of \(q\) abcissae
-        integer :: kx  = 0  !! The order of spline pieces in \(x\)
-        integer :: ky  = 0  !! The order of spline pieces in \(y\)
-        integer :: kz  = 0  !! The order of spline pieces in \(z\)
-        integer :: kq  = 0  !! The order of spline pieces in \(q\)
+        integer(ip) :: nx = 0_ip  !! Number of \(x\) abcissae
+        integer(ip) :: ny = 0_ip  !! Number of \(y\) abcissae
+        integer(ip) :: nz = 0_ip  !! Number of \(z\) abcissae
+        integer(ip) :: nq = 0_ip  !! Number of \(q\) abcissae
+        integer(ip) :: kx = 0_ip  !! The order of spline pieces in \(x\)
+        integer(ip) :: ky = 0_ip  !! The order of spline pieces in \(y\)
+        integer(ip) :: kz = 0_ip  !! The order of spline pieces in \(z\)
+        integer(ip) :: kq = 0_ip  !! The order of spline pieces in \(q\)
         real(wp),dimension(:,:,:,:),allocatable :: bcoef  !! array of coefficients of the b-spline interpolant
         real(wp),dimension(:),allocatable :: tx  !! The knots in the \(x\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: ty  !! The knots in the \(y\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: tz  !! The knots in the \(z\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: tq  !! The knots in the \(q\) direction for the spline interpolant
-        integer :: inbvy = 1  !! internal variable used for efficient processing
-        integer :: inbvz = 1  !! internal variable used for efficient processing
-        integer :: inbvq = 1  !! internal variable used for efficient processing
-        integer :: iloy  = 1  !! internal variable used for efficient processing
-        integer :: iloz  = 1  !! internal variable used for efficient processing
-        integer :: iloq  = 1  !! internal variable used for efficient processing
+        integer(ip) :: inbvy = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: inbvz = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: inbvq = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloy  = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloz  = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloq  = 1_ip  !! internal variable used for efficient processing
         real(wp),dimension(:,:,:),allocatable :: work_val_1  !! [[db4val]] work array of dimension `ky,kz,kq`
         real(wp),dimension(:,:),allocatable   :: work_val_2  !! [[db4val]] work array of dimension `kz,kq`
         real(wp),dimension(:),allocatable     :: work_val_3  !! [[db4val]] work array of dimension `kq`
-        real(wp),dimension(:),allocatable     :: work_val_4  !! [[db4val]] work array of dimension `3*max(kx,ky,kz,kq)`
+        real(wp),dimension(:),allocatable     :: work_val_4  !! [[db4val]] work array of dimension `3_ip*max(kx,ky,kz,kq)`
         contains
         private
         generic,public :: initialize => initialize_4d_auto_knots,initialize_4d_specify_knots
@@ -180,35 +180,35 @@
     type,extends(bspline_class),public :: bspline_5d
         !! Class for 5d b-spline interpolation.
         private
-        integer :: nx  = 0  !! Number of \(x\) abcissae
-        integer :: ny  = 0  !! Number of \(y\) abcissae
-        integer :: nz  = 0  !! Number of \(z\) abcissae
-        integer :: nq  = 0  !! Number of \(q\) abcissae
-        integer :: nr  = 0  !! Number of \(r\) abcissae
-        integer :: kx  = 0  !! The order of spline pieces in \(x\)
-        integer :: ky  = 0  !! The order of spline pieces in \(y\)
-        integer :: kz  = 0  !! The order of spline pieces in \(z\)
-        integer :: kq  = 0  !! The order of spline pieces in \(q\)
-        integer :: kr  = 0  !! The order of spline pieces in \(r\)
+        integer(ip) :: nx = 0_ip  !! Number of \(x\) abcissae
+        integer(ip) :: ny = 0_ip  !! Number of \(y\) abcissae
+        integer(ip) :: nz = 0_ip  !! Number of \(z\) abcissae
+        integer(ip) :: nq = 0_ip  !! Number of \(q\) abcissae
+        integer(ip) :: nr = 0_ip  !! Number of \(r\) abcissae
+        integer(ip) :: kx = 0_ip  !! The order of spline pieces in \(x\)
+        integer(ip) :: ky = 0_ip  !! The order of spline pieces in \(y\)
+        integer(ip) :: kz = 0_ip  !! The order of spline pieces in \(z\)
+        integer(ip) :: kq = 0_ip  !! The order of spline pieces in \(q\)
+        integer(ip) :: kr = 0_ip  !! The order of spline pieces in \(r\)
         real(wp),dimension(:,:,:,:,:),allocatable :: bcoef  !! array of coefficients of the b-spline interpolant
         real(wp),dimension(:),allocatable :: tx  !! The knots in the \(x\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: ty  !! The knots in the \(y\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: tz  !! The knots in the \(z\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: tq  !! The knots in the \(q\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: tr  !! The knots in the \(r\) direction for the spline interpolant
-        integer :: inbvy = 1  !! internal variable used for efficient processing
-        integer :: inbvz = 1  !! internal variable used for efficient processing
-        integer :: inbvq = 1  !! internal variable used for efficient processing
-        integer :: inbvr = 1  !! internal variable used for efficient processing
-        integer :: iloy  = 1  !! internal variable used for efficient processing
-        integer :: iloz  = 1  !! internal variable used for efficient processing
-        integer :: iloq  = 1  !! internal variable used for efficient processing
-        integer :: ilor  = 1  !! internal variable used for efficient processing
+        integer(ip) :: inbvy = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: inbvz = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: inbvq = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: inbvr = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloy  = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloz  = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloq  = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: ilor  = 1_ip  !! internal variable used for efficient processing
         real(wp),dimension(:,:,:,:),allocatable :: work_val_1  !! [[db5val]] work array of dimension `ky,kz,kq,kr`
         real(wp),dimension(:,:,:),allocatable   :: work_val_2  !! [[db5val]] work array of dimension `kz,kq,kr`
         real(wp),dimension(:,:),allocatable     :: work_val_3  !! [[db5val]] work array of dimension `kq,kr`
         real(wp),dimension(:),allocatable       :: work_val_4  !! [[db5val]] work array of dimension `kr`
-        real(wp),dimension(:),allocatable       :: work_val_5  !! [[db5val]] work array of dimension `3*max(kx,ky,kz,kq,kr)`
+        real(wp),dimension(:),allocatable       :: work_val_5  !! [[db5val]] work array of dimension `3_ip*max(kx,ky,kz,kq,kr)`
         contains
         private
         generic,public :: initialize => initialize_5d_auto_knots,initialize_5d_specify_knots
@@ -223,18 +223,18 @@
     type,extends(bspline_class),public :: bspline_6d
         !! Class for 6d b-spline interpolation.
         private
-        integer :: nx  = 0  !! Number of \(x\) abcissae
-        integer :: ny  = 0  !! Number of \(y\) abcissae
-        integer :: nz  = 0  !! Number of \(z\) abcissae
-        integer :: nq  = 0  !! Number of \(q\) abcissae
-        integer :: nr  = 0  !! Number of \(r\) abcissae
-        integer :: ns  = 0  !! Number of \(s\) abcissae
-        integer :: kx  = 0  !! The order of spline pieces in \(x\)
-        integer :: ky  = 0  !! The order of spline pieces in \(y\)
-        integer :: kz  = 0  !! The order of spline pieces in \(z\)
-        integer :: kq  = 0  !! The order of spline pieces in \(q\)
-        integer :: kr  = 0  !! The order of spline pieces in \(r\)
-        integer :: ks  = 0  !! The order of spline pieces in \(s\)
+        integer(ip) :: nx = 0_ip  !! Number of \(x\) abcissae
+        integer(ip) :: ny = 0_ip  !! Number of \(y\) abcissae
+        integer(ip) :: nz = 0_ip  !! Number of \(z\) abcissae
+        integer(ip) :: nq = 0_ip  !! Number of \(q\) abcissae
+        integer(ip) :: nr = 0_ip  !! Number of \(r\) abcissae
+        integer(ip) :: ns = 0_ip  !! Number of \(s\) abcissae
+        integer(ip) :: kx = 0_ip  !! The order of spline pieces in \(x\)
+        integer(ip) :: ky = 0_ip  !! The order of spline pieces in \(y\)
+        integer(ip) :: kz = 0_ip  !! The order of spline pieces in \(z\)
+        integer(ip) :: kq = 0_ip  !! The order of spline pieces in \(q\)
+        integer(ip) :: kr = 0_ip  !! The order of spline pieces in \(r\)
+        integer(ip) :: ks = 0_ip  !! The order of spline pieces in \(s\)
         real(wp),dimension(:,:,:,:,:,:),allocatable :: bcoef  !! array of coefficients of the b-spline interpolant
         real(wp),dimension(:),allocatable :: tx  !! The knots in the \(x\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: ty  !! The knots in the \(y\) direction for the spline interpolant
@@ -242,22 +242,22 @@
         real(wp),dimension(:),allocatable :: tq  !! The knots in the \(q\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: tr  !! The knots in the \(r\) direction for the spline interpolant
         real(wp),dimension(:),allocatable :: ts  !! The knots in the \(s\) direction for the spline interpolant
-        integer :: inbvy = 1  !! internal variable used for efficient processing
-        integer :: inbvz = 1  !! internal variable used for efficient processing
-        integer :: inbvq = 1  !! internal variable used for efficient processing
-        integer :: inbvr = 1  !! internal variable used for efficient processing
-        integer :: inbvs = 1  !! internal variable used for efficient processing
-        integer :: iloy  = 1  !! internal variable used for efficient processing
-        integer :: iloz  = 1  !! internal variable used for efficient processing
-        integer :: iloq  = 1  !! internal variable used for efficient processing
-        integer :: ilor  = 1  !! internal variable used for efficient processing
-        integer :: ilos  = 1  !! internal variable used for efficient processing
+        integer(ip) :: inbvy = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: inbvz = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: inbvq = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: inbvr = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: inbvs = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloy  = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloz  = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: iloq  = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: ilor  = 1_ip  !! internal variable used for efficient processing
+        integer(ip) :: ilos  = 1_ip  !! internal variable used for efficient processing
         real(wp),dimension(:,:,:,:,:),allocatable :: work_val_1  !! [[db6val]] work array of dimension `ky,kz,kq,kr,ks`
         real(wp),dimension(:,:,:,:),allocatable   :: work_val_2  !! [[db6val]] work array of dimension `kz,kq,kr,ks`
         real(wp),dimension(:,:,:),allocatable     :: work_val_3  !! [[db6val]] work array of dimension `kq,kr,ks`
         real(wp),dimension(:,:),allocatable       :: work_val_4  !! [[db6val]] work array of dimension `kr,ks`
         real(wp),dimension(:),allocatable         :: work_val_5  !! [[db6val]] work array of dimension `ks`
-        real(wp),dimension(:),allocatable         :: work_val_6  !! [[db6val]] work array of dimension `3*max(kx,ky,kz,kq,kr,ks)`
+        real(wp),dimension(:),allocatable         :: work_val_6  !! [[db6val]] work array of dimension `3_ip*max(kx,ky,kz,kq,kr,ks)`
         contains
         private
         generic,public :: initialize => initialize_6d_auto_knots,initialize_6d_specify_knots
@@ -333,7 +333,7 @@
     class(bspline_class),intent(in) :: me
     logical                         :: ok
 
-    ok = ( me%iflag == 0 )
+    ok = ( me%iflag == 0_ip )
 
     end function status_ok
 !*****************************************************************************************
@@ -350,7 +350,7 @@
 
     class(bspline_class),intent(inout) :: me
 
-    me%iflag = 0
+    me%iflag = 0_ip
 
     end subroutine clear_bspline_flag
 !*****************************************************************************************
@@ -372,7 +372,7 @@
 
     class(bspline_class),intent(in) :: me
     character(len=:),allocatable    :: msg    !! status message associated with the flag
-    integer,intent(in),optional     :: iflag  !! the corresponding status code
+    integer(ip),intent(in),optional :: iflag  !! the corresponding status code
 
     if (present(iflag)) then
         msg = get_status_message(iflag)
@@ -392,13 +392,13 @@
     implicit none
 
     class(bspline_1d),intent(in) :: me
-    integer :: s !! size of the structure in bits
+    integer(ip) :: s !! size of the structure in bits
 
-    s = 2*int_size + logical_size + 2*int_size
+    s = 2_ip*int_size + logical_size + 2_ip*int_size
 
-    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef)
-    if (allocated(me%tx))         s = s + real_size*size(me%tx)
-    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,kind=ip)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx,kind=ip)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,kind=ip)
 
     end function size_1d
 !*****************************************************************************************
@@ -412,16 +412,16 @@
     implicit none
 
     class(bspline_2d),intent(in) :: me
-    integer :: s !! size of the structure in bits
+    integer(ip) :: s !! size of the structure in bits
 
-    s = 2*int_size + logical_size + 6*int_size
+    s = 2_ip*int_size + logical_size + 6_ip*int_size
 
-    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1)*&
-                                                    size(me%bcoef,2)
-    if (allocated(me%tx))         s = s + real_size*size(me%tx)
-    if (allocated(me%ty))         s = s + real_size*size(me%ty)
-    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1)
-    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1_ip,kind=ip)*&
+                                                    size(me%bcoef,2_ip,kind=ip)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx,kind=ip)
+    if (allocated(me%ty))         s = s + real_size*size(me%ty,kind=ip)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,kind=ip)
+    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,kind=ip)
 
     end function size_2d
 !*****************************************************************************************
@@ -435,20 +435,20 @@
     implicit none
 
     class(bspline_3d),intent(in) :: me
-    integer :: s !! size of the structure in bits
+    integer(ip) :: s !! size of the structure in bits
 
-    s = 2*int_size + logical_size + 10*int_size
+    s = 2_ip*int_size + logical_size + 10_ip*int_size
 
-    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1)*&
-                                                    size(me%bcoef,2)*&
-                                                    size(me%bcoef,3)
-    if (allocated(me%tx))         s = s + real_size*size(me%tx)
-    if (allocated(me%ty))         s = s + real_size*size(me%ty)
-    if (allocated(me%tz))         s = s + real_size*size(me%tz)
-    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1)*&
-                                                    size(me%work_val_1,2)
-    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2)
-    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1_ip,kind=ip)*&
+                                                    size(me%bcoef,2_ip,kind=ip)*&
+                                                    size(me%bcoef,3_ip,kind=ip)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx,kind=ip)
+    if (allocated(me%ty))         s = s + real_size*size(me%ty,kind=ip)
+    if (allocated(me%tz))         s = s + real_size*size(me%tz,kind=ip)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1_ip,kind=ip)*&
+                                                    size(me%work_val_1,2_ip,kind=ip)
+    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,kind=ip)
+    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3,kind=ip)
 
     end function size_3d
 !*****************************************************************************************
@@ -462,25 +462,25 @@
     implicit none
 
     class(bspline_4d),intent(in) :: me
-    integer :: s !! size of the structure in bits
+    integer(ip) :: s !! size of the structure in bits
 
-    s = 2*int_size + logical_size + 14*int_size
+    s = 2_ip*int_size + logical_size + 14_ip*int_size
 
-    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1)*&
-                                                    size(me%bcoef,2)*&
-                                                    size(me%bcoef,3)*&
-                                                    size(me%bcoef,4)
-    if (allocated(me%tx))         s = s + real_size*size(me%tx)
-    if (allocated(me%ty))         s = s + real_size*size(me%ty)
-    if (allocated(me%tz))         s = s + real_size*size(me%tz)
-    if (allocated(me%tq))         s = s + real_size*size(me%tq)
-    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1)*&
-                                                    size(me%work_val_1,2)*&
-                                                    size(me%work_val_1,3)
-    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,1)*&
-                                                    size(me%work_val_2,2)
-    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3)
-    if (allocated(me%work_val_4)) s = s + real_size*size(me%work_val_4)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1_ip,kind=ip)*&
+                                                    size(me%bcoef,2_ip,kind=ip)*&
+                                                    size(me%bcoef,3_ip,kind=ip)*&
+                                                    size(me%bcoef,4_ip,kind=ip)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx,kind=ip)
+    if (allocated(me%ty))         s = s + real_size*size(me%ty,kind=ip)
+    if (allocated(me%tz))         s = s + real_size*size(me%tz,kind=ip)
+    if (allocated(me%tq))         s = s + real_size*size(me%tq,kind=ip)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1_ip,kind=ip)*&
+                                                    size(me%work_val_1,2_ip,kind=ip)*&
+                                                    size(me%work_val_1,3_ip,kind=ip)
+    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,1_ip,kind=ip)*&
+                                                    size(me%work_val_2,2_ip,kind=ip)
+    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3,kind=ip)
+    if (allocated(me%work_val_4)) s = s + real_size*size(me%work_val_4,kind=ip)
 
     end function size_4d
 !*****************************************************************************************
@@ -494,31 +494,31 @@
     implicit none
 
     class(bspline_5d),intent(in) :: me
-    integer :: s !! size of the structure in bits
+    integer(ip) :: s !! size of the structure in bits
 
-    s = 2*int_size + logical_size + 18*int_size
+    s = 2_ip*int_size + logical_size + 18_ip*int_size
 
-    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1)*&
-                                                    size(me%bcoef,2)*&
-                                                    size(me%bcoef,3)*&
-                                                    size(me%bcoef,4)*&
-                                                    size(me%bcoef,5)
-    if (allocated(me%tx))         s = s + real_size*size(me%tx)
-    if (allocated(me%ty))         s = s + real_size*size(me%ty)
-    if (allocated(me%tz))         s = s + real_size*size(me%tz)
-    if (allocated(me%tq))         s = s + real_size*size(me%tq)
-    if (allocated(me%tr))         s = s + real_size*size(me%tr)
-    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1)*&
-                                                    size(me%work_val_1,2)*&
-                                                    size(me%work_val_1,3)*&
-                                                    size(me%work_val_1,4)
-    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,1)*&
-                                                    size(me%work_val_2,2)*&
-                                                    size(me%work_val_2,3)
-    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3,1)*&
-                                                    size(me%work_val_3,2)
-    if (allocated(me%work_val_4)) s = s + real_size*size(me%work_val_4)
-    if (allocated(me%work_val_5)) s = s + real_size*size(me%work_val_5)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1_ip,kind=ip)*&
+                                                    size(me%bcoef,2_ip,kind=ip)*&
+                                                    size(me%bcoef,3_ip,kind=ip)*&
+                                                    size(me%bcoef,4_ip,kind=ip)*&
+                                                    size(me%bcoef,5_ip,kind=ip)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx,kind=ip)
+    if (allocated(me%ty))         s = s + real_size*size(me%ty,kind=ip)
+    if (allocated(me%tz))         s = s + real_size*size(me%tz,kind=ip)
+    if (allocated(me%tq))         s = s + real_size*size(me%tq,kind=ip)
+    if (allocated(me%tr))         s = s + real_size*size(me%tr,kind=ip)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1_ip,kind=ip)*&
+                                                    size(me%work_val_1,2_ip,kind=ip)*&
+                                                    size(me%work_val_1,3_ip,kind=ip)*&
+                                                    size(me%work_val_1,4_ip,kind=ip)
+    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,1_ip,kind=ip)*&
+                                                    size(me%work_val_2,2_ip,kind=ip)*&
+                                                    size(me%work_val_2,3_ip,kind=ip)
+    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3,1_ip,kind=ip)*&
+                                                    size(me%work_val_3,2_ip,kind=ip)
+    if (allocated(me%work_val_4)) s = s + real_size*size(me%work_val_4,kind=ip)
+    if (allocated(me%work_val_5)) s = s + real_size*size(me%work_val_5,kind=ip)
 
     end function size_5d
 !*****************************************************************************************
@@ -532,38 +532,38 @@
     implicit none
 
     class(bspline_6d),intent(in) :: me
-    integer :: s !! size of the structure in bits
+    integer(ip) :: s !! size of the structure in bits
 
-    s = 2*int_size + logical_size + 22*int_size
+    s = 2_ip*int_size + logical_size + 22_ip*int_size
 
-    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1)*&
-                                                    size(me%bcoef,2)*&
-                                                    size(me%bcoef,3)*&
-                                                    size(me%bcoef,4)*&
-                                                    size(me%bcoef,5)*&
-                                                    size(me%bcoef,6)
-    if (allocated(me%tx))         s = s + real_size*size(me%tx)
-    if (allocated(me%ty))         s = s + real_size*size(me%ty)
-    if (allocated(me%tz))         s = s + real_size*size(me%tz)
-    if (allocated(me%tq))         s = s + real_size*size(me%tq)
-    if (allocated(me%tr))         s = s + real_size*size(me%tr)
-    if (allocated(me%ts))         s = s + real_size*size(me%ts)
-    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1)*&
-                                                    size(me%work_val_1,2)*&
-                                                    size(me%work_val_1,3)*&
-                                                    size(me%work_val_1,4)*&
-                                                    size(me%work_val_1,5)
-    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,1)*&
-                                                    size(me%work_val_2,2)*&
-                                                    size(me%work_val_2,3)*&
-                                                    size(me%work_val_2,4)
-    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3,1)*&
-                                                    size(me%work_val_3,2)*&
-                                                    size(me%work_val_3,3)
-    if (allocated(me%work_val_4)) s = s + real_size*size(me%work_val_4,1)*&
-                                                    size(me%work_val_4,2)
-    if (allocated(me%work_val_5)) s = s + real_size*size(me%work_val_5)
-    if (allocated(me%work_val_6)) s = s + real_size*size(me%work_val_6)
+    if (allocated(me%bcoef))      s = s + real_size*size(me%bcoef,1_ip,kind=ip)*&
+                                                    size(me%bcoef,2_ip,kind=ip)*&
+                                                    size(me%bcoef,3_ip,kind=ip)*&
+                                                    size(me%bcoef,4_ip,kind=ip)*&
+                                                    size(me%bcoef,5_ip,kind=ip)*&
+                                                    size(me%bcoef,6,kind=ip)
+    if (allocated(me%tx))         s = s + real_size*size(me%tx,kind=ip)
+    if (allocated(me%ty))         s = s + real_size*size(me%ty,kind=ip)
+    if (allocated(me%tz))         s = s + real_size*size(me%tz,kind=ip)
+    if (allocated(me%tq))         s = s + real_size*size(me%tq,kind=ip)
+    if (allocated(me%tr))         s = s + real_size*size(me%tr,kind=ip)
+    if (allocated(me%ts))         s = s + real_size*size(me%ts,kind=ip)
+    if (allocated(me%work_val_1)) s = s + real_size*size(me%work_val_1,1_ip,kind=ip)*&
+                                                    size(me%work_val_1,2_ip,kind=ip)*&
+                                                    size(me%work_val_1,3_ip,kind=ip)*&
+                                                    size(me%work_val_1,4_ip,kind=ip)*&
+                                                    size(me%work_val_1,5_ip,kind=ip)
+    if (allocated(me%work_val_2)) s = s + real_size*size(me%work_val_2,1_ip,kind=ip)*&
+                                                    size(me%work_val_2,2_ip,kind=ip)*&
+                                                    size(me%work_val_2,3_ip,kind=ip)*&
+                                                    size(me%work_val_2,4_ip,kind=ip)
+    if (allocated(me%work_val_3)) s = s + real_size*size(me%work_val_3,1_ip,kind=ip)*&
+                                                    size(me%work_val_3,2_ip,kind=ip)*&
+                                                    size(me%work_val_3,3_ip,kind=ip)
+    if (allocated(me%work_val_4)) s = s + real_size*size(me%work_val_4,1_ip,kind=ip)*&
+                                                    size(me%work_val_4,2_ip,kind=ip)
+    if (allocated(me%work_val_5)) s = s + real_size*size(me%work_val_5,kind=ip)
+    if (allocated(me%work_val_6)) s = s + real_size*size(me%work_val_6,kind=ip)
 
     end function size_6d
 !*****************************************************************************************
@@ -579,8 +579,8 @@
 
     class(bspline_class),intent(inout) :: me
 
-    me%inbvx = 1
-    me%iflag = 1
+    me%inbvx = 1_ip
+    me%iflag = 1_ip
     me%initialized = .false.
     me%extrap = .false.
 
@@ -599,8 +599,8 @@
 
     call me%destroy_base()
 
-    me%nx  = 0
-    me%kx  = 0
+    me%nx = 0_ip
+    me%kx = 0_ip
     if (allocated(me%bcoef))      deallocate(me%bcoef)
     if (allocated(me%tx))         deallocate(me%tx)
     if (allocated(me%work_val_1)) deallocate(me%work_val_1)
@@ -620,12 +620,12 @@
 
     call me%destroy_base()
 
-    me%nx    = 0
-    me%ny    = 0
-    me%kx    = 0
-    me%ky    = 0
-    me%inbvy = 1
-    me%iloy  = 1
+    me%nx    = 0_ip
+    me%ny    = 0_ip
+    me%kx    = 0_ip
+    me%ky    = 0_ip
+    me%inbvy = 1_ip
+    me%iloy  = 1_ip
     if (allocated(me%bcoef))      deallocate(me%bcoef)
     if (allocated(me%tx))         deallocate(me%tx)
     if (allocated(me%ty))         deallocate(me%ty)
@@ -647,16 +647,16 @@
 
     call me%destroy_base()
 
-    me%nx    = 0
-    me%ny    = 0
-    me%nz    = 0
-    me%kx    = 0
-    me%ky    = 0
-    me%kz    = 0
-    me%inbvy = 1
-    me%inbvz = 1
-    me%iloy  = 1
-    me%iloz  = 1
+    me%nx    = 0_ip
+    me%ny    = 0_ip
+    me%nz    = 0_ip
+    me%kx    = 0_ip
+    me%ky    = 0_ip
+    me%kz    = 0_ip
+    me%inbvy = 1_ip
+    me%inbvz = 1_ip
+    me%iloy  = 1_ip
+    me%iloz  = 1_ip
     if (allocated(me%bcoef))      deallocate(me%bcoef)
     if (allocated(me%tx))         deallocate(me%tx)
     if (allocated(me%ty))         deallocate(me%ty)
@@ -678,20 +678,20 @@
 
     class(bspline_4d),intent(inout) :: me
 
-    me%nx    = 0
-    me%ny    = 0
-    me%nz    = 0
-    me%nq    = 0
-    me%kx    = 0
-    me%ky    = 0
-    me%kz    = 0
-    me%kq    = 0
-    me%inbvy = 1
-    me%inbvz = 1
-    me%inbvq = 1
-    me%iloy  = 1
-    me%iloz  = 1
-    me%iloq  = 1
+    me%nx    = 0_ip
+    me%ny    = 0_ip
+    me%nz    = 0_ip
+    me%nq    = 0_ip
+    me%kx    = 0_ip
+    me%ky    = 0_ip
+    me%kz    = 0_ip
+    me%kq    = 0_ip
+    me%inbvy = 1_ip
+    me%inbvz = 1_ip
+    me%inbvq = 1_ip
+    me%iloy  = 1_ip
+    me%iloz  = 1_ip
+    me%iloq  = 1_ip
     if (allocated(me%bcoef))      deallocate(me%bcoef)
     if (allocated(me%tx))         deallocate(me%tx)
     if (allocated(me%ty))         deallocate(me%ty)
@@ -715,24 +715,24 @@
 
     class(bspline_5d),intent(inout) :: me
 
-    me%nx    = 0
-    me%ny    = 0
-    me%nz    = 0
-    me%nq    = 0
-    me%nr    = 0
-    me%kx    = 0
-    me%ky    = 0
-    me%kz    = 0
-    me%kq    = 0
-    me%kr    = 0
-    me%inbvy = 1
-    me%inbvz = 1
-    me%inbvq = 1
-    me%inbvr = 1
-    me%iloy  = 1
-    me%iloz  = 1
-    me%iloq  = 1
-    me%ilor  = 1
+    me%nx    = 0_ip
+    me%ny    = 0_ip
+    me%nz    = 0_ip
+    me%nq    = 0_ip
+    me%nr    = 0_ip
+    me%kx    = 0_ip
+    me%ky    = 0_ip
+    me%kz    = 0_ip
+    me%kq    = 0_ip
+    me%kr    = 0_ip
+    me%inbvy = 1_ip
+    me%inbvz = 1_ip
+    me%inbvq = 1_ip
+    me%inbvr = 1_ip
+    me%iloy  = 1_ip
+    me%iloz  = 1_ip
+    me%iloq  = 1_ip
+    me%ilor  = 1_ip
     if (allocated(me%bcoef))      deallocate(me%bcoef)
     if (allocated(me%tx))         deallocate(me%tx)
     if (allocated(me%ty))         deallocate(me%ty)
@@ -758,28 +758,28 @@
 
     class(bspline_6d),intent(inout) :: me
 
-    me%nx    = 0
-    me%ny    = 0
-    me%nz    = 0
-    me%nq    = 0
-    me%nr    = 0
-    me%ns    = 0
-    me%kx    = 0
-    me%ky    = 0
-    me%kz    = 0
-    me%kq    = 0
-    me%kr    = 0
-    me%ks    = 0
-    me%inbvy = 1
-    me%inbvz = 1
-    me%inbvq = 1
-    me%inbvr = 1
-    me%inbvs = 1
-    me%iloy  = 1
-    me%iloz  = 1
-    me%iloq  = 1
-    me%ilor  = 1
-    me%ilos  = 1
+    me%nx    = 0_ip
+    me%ny    = 0_ip
+    me%nz    = 0_ip
+    me%nq    = 0_ip
+    me%nr    = 0_ip
+    me%ns    = 0_ip
+    me%kx    = 0_ip
+    me%ky    = 0_ip
+    me%kz    = 0_ip
+    me%kq    = 0_ip
+    me%kr    = 0_ip
+    me%ks    = 0_ip
+    me%inbvy = 1_ip
+    me%inbvz = 1_ip
+    me%inbvq = 1_ip
+    me%inbvr = 1_ip
+    me%inbvs = 1_ip
+    me%iloy  = 1_ip
+    me%iloz  = 1_ip
+    me%iloq  = 1_ip
+    me%ilor  = 1_ip
+    me%ilos  = 1_ip
     if (allocated(me%bcoef))      deallocate(me%bcoef)
     if (allocated(me%tx))         deallocate(me%tx)
     if (allocated(me%ty))         deallocate(me%ty)
@@ -888,7 +888,7 @@
     real(wp),dimension(:),intent(in) :: x      !! `(nx)` array of \(x\) abcissae. Must be strictly increasing.
     real(wp),dimension(:),intent(in) :: fcn    !! `(nx)` array of function values to interpolate. `fcn(i)` should
                                                !! contain the function value at the point `x(i)`
-    integer,intent(in)               :: kx     !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)           :: kx     !! The order of spline pieces in \(x\)
                                                !! ( \( 2 \le k_x < n_x \) )
                                                !! (order = polynomial degree + 1)
     logical,intent(in),optional      :: extrap !! if true, then extrapolation is allowed
@@ -912,7 +912,7 @@
     real(wp),dimension(:),intent(in) :: x     !! `(nx)` array of \(x\) abcissae. Must be strictly increasing.
     real(wp),dimension(:),intent(in) :: fcn   !! `(nx)` array of function values to interpolate. `fcn(i)` should
                                               !! contain the function value at the point `x(i)`
-    integer,intent(in)               :: kx    !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)           :: kx    !! The order of spline pieces in \(x\)
                                               !! ( \( 2 \le k_x < n_x \) )
                                               !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in) :: tx    !! The `(nx+kx)` knots in the \(x\) direction
@@ -939,36 +939,36 @@
     real(wp),dimension(:),intent(in) :: x     !! `(nx)` array of \(x\) abcissae. Must be strictly increasing.
     real(wp),dimension(:),intent(in) :: fcn   !! `(nx)` array of function values to interpolate. `fcn(i)` should
                                               !! contain the function value at the point `x(i)`
-    integer,intent(in)               :: kx    !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)           :: kx    !! The order of spline pieces in \(x\)
                                               !! ( \( 2 \le k_x < n_x \) )
                                               !! (order = polynomial degree + 1)
-    integer,intent(out)              :: iflag !! status flag (see [[db1ink]])
+    integer(ip),intent(out)          :: iflag !! status flag (see [[db1ink]])
     logical,intent(in),optional      :: extrap !! if true, then extrapolation is allowed
                                                !! (default is false)
 
-    integer :: iknot
-    integer :: nx
+    integer(ip) :: iknot
+    integer(ip) :: nx
 
     call me%destroy()
 
-    nx = size(x)
+    nx = size(x,kind=ip)
 
     me%nx = nx
     me%kx = kx
 
     allocate(me%tx(nx+kx))
     allocate(me%bcoef(nx))
-    allocate(me%work_val_1(3*kx))
+    allocate(me%work_val_1(3_ip*kx))
 
-    iknot = 0         !knot sequence chosen by db1ink
+    iknot = 0_ip         !knot sequence chosen by db1ink
 
     call db1ink(x,nx,fcn,kx,iknot,me%tx,me%bcoef,iflag)
 
-    if (iflag==0) then
+    if (iflag==0_ip) then
         call me%set_extrap_flag(extrap)
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_1d_auto_knots
@@ -987,42 +987,42 @@
     real(wp),dimension(:),intent(in) :: x     !! `(nx)` array of \(x\) abcissae. Must be strictly increasing.
     real(wp),dimension(:),intent(in) :: fcn   !! `(nx)` array of function values to interpolate. `fcn(i)` should
                                               !! contain the function value at the point `x(i)`
-    integer,intent(in)               :: kx    !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)           :: kx    !! The order of spline pieces in \(x\)
                                               !! ( \( 2 \le k_x < n_x \) )
                                               !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in) :: tx    !! The `(nx+kx)` knots in the \(x\) direction
                                               !! for the spline interpolant.
                                               !! Must be non-decreasing.
-    integer,intent(out)              :: iflag !! status flag (see [[db1ink]])
+    integer(ip),intent(out)          :: iflag !! status flag (see [[db1ink]])
     logical,intent(in),optional      :: extrap !! if true, then extrapolation is allowed
                                                !! (default is false)
 
-    integer :: nx
+    integer(ip) :: nx
 
     call me%destroy()
 
-    nx = size(x)
+    nx = size(x,kind=ip)
 
     call check_knot_vectors_sizes(nx=nx,kx=kx,tx=tx,iflag=iflag)
 
-    if (iflag == 0) then
+    if (iflag == 0_ip) then
 
         me%nx = nx
         me%kx = kx
 
         allocate(me%tx(nx+kx))
         allocate(me%bcoef(nx))
-        allocate(me%work_val_1(3*kx))
+        allocate(me%work_val_1(3_ip*kx))
 
         me%tx = tx
 
-        call db1ink(x,nx,fcn,kx,1,me%tx,me%bcoef,iflag)
+        call db1ink(x,nx,fcn,kx,1_ip,me%tx,me%bcoef,iflag)
 
         call me%set_extrap_flag(extrap)
 
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_1d_specify_knots
@@ -1038,15 +1038,15 @@
 
     class(bspline_1d),intent(inout) :: me
     real(wp),intent(in)             :: xval  !! \(x\) coordinate of evaluation point.
-    integer,intent(in)              :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
     real(wp),intent(out)            :: f     !! interpolated value
-    integer,intent(out)             :: iflag !! status flag (see [[db1val]])
+    integer(ip),intent(out)         :: iflag !! status flag (see [[db1val]])
 
     if (me%initialized) then
         call db1val(xval,idx,me%tx,me%nx,me%kx,me%bcoef,f,iflag,&
                     me%inbvx,me%work_val_1,extrap=me%extrap)
     else
-        iflag = 1
+        iflag = 1_ip
     end if
     me%iflag = iflag
 
@@ -1065,12 +1065,12 @@
     real(wp),intent(in)             :: x1    !! left point of interval
     real(wp),intent(in)             :: x2    !! right point of interval
     real(wp),intent(out)            :: f     !! integral of the b-spline over \( [x_1, x_2] \)
-    integer,intent(out)             :: iflag !! status flag (see [[db1sqad]])
+    integer(ip),intent(out)         :: iflag !! status flag (see [[db1sqad]])
 
     if (me%initialized) then
         call db1sqad(me%tx,me%bcoef,me%nx,me%kx,x1,x2,f,iflag,me%work_val_1)
     else
-        iflag = 1
+        iflag = 1_ip
     end if
     me%iflag = iflag
 
@@ -1088,18 +1088,18 @@
     class(bspline_1d),intent(inout) :: me
     procedure(b1fqad_func)          :: fun   !! external function of one argument for the
                                              !! integrand `bf(x)=fun(x)*dbvalu(tx,bcoef,nx,kx,idx,x,inbv)`
-    integer,intent(in)              :: idx   !! order of the spline derivative, `0 <= idx <= k-1`
+    integer(ip),intent(in)          :: idx   !! order of the spline derivative, `0 <= idx <= k-1`
                                              !! `idx=0` gives the spline function
     real(wp),intent(in)             :: x1    !! left point of interval
     real(wp),intent(in)             :: x2    !! right point of interval
     real(wp),intent(in)             :: tol   !! desired accuracy for the quadrature
     real(wp),intent(out)            :: f     !! integral of `bf(x)` over \( [x_1, x_2] \)
-    integer,intent(out)             :: iflag !! status flag (see [[db1sqad]])
+    integer(ip),intent(out)         :: iflag !! status flag (see [[db1sqad]])
 
     if (me%initialized) then
         call db1fqad(fun,me%tx,me%bcoef,me%nx,me%kx,idx,x1,x2,tol,f,iflag,me%work_val_1)
     else
-        iflag = 1
+        iflag = 1_ip
     end if
     me%iflag = iflag
 
@@ -1136,14 +1136,14 @@
     real(wp),dimension(:,:),intent(in) :: fcn   !! `(nx,ny)` matrix of function values to interpolate.
                                                 !! `fcn(i,j)` should contain the function value at the
                                                 !! point (`x(i)`,`y(j)`)
-    integer,intent(in)                 :: kx    !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)             :: kx    !! The order of spline pieces in \(x\)
                                                 !! ( \( 2 \le k_x < n_x \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                 :: ky    !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)             :: ky    !! The order of spline pieces in \(y\)
                                                 !! ( \( 2 \le k_y < n_y \) )
                                                 !! (order = polynomial degree + 1)
-    logical,intent(in),optional      :: extrap !! if true, then extrapolation is allowed
-                                               !! (default is false)
+    logical,intent(in),optional      :: extrap  !! if true, then extrapolation is allowed
+                                                !! (default is false)
 
     call initialize_2d_auto_knots(me,x,y,fcn,kx,ky,me%iflag,extrap)
 
@@ -1165,10 +1165,10 @@
     real(wp),dimension(:,:),intent(in) :: fcn   !! `(nx,ny)` matrix of function values to interpolate.
                                                 !! `fcn(i,j)` should contain the function value at the
                                                 !! point (`x(i)`,`y(j)`)
-    integer,intent(in)                 :: kx    !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)             :: kx    !! The order of spline pieces in \(x\)
                                                 !! ( \( 2 \le k_x < n_x \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                 :: ky    !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)             :: ky    !! The order of spline pieces in \(y\)
                                                 !! ( \( 2 \le k_y < n_y \) )
                                                 !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)   :: tx    !! The `(nx+kx)` knots in the \(x\) direction
@@ -1200,23 +1200,23 @@
     real(wp),dimension(:,:),intent(in) :: fcn   !! `(nx,ny)` matrix of function values to interpolate.
                                                 !! `fcn(i,j)` should contain the function value at the
                                                 !! point (`x(i)`,`y(j)`)
-    integer,intent(in)                 :: kx    !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)             :: kx    !! The order of spline pieces in \(x\)
                                                 !! ( \( 2 \le k_x < n_x \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                 :: ky    !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)             :: ky    !! The order of spline pieces in \(y\)
                                                 !! ( \( 2 \le k_y < n_y \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(out)                :: iflag !! status flag (see [[db2ink]])
-    logical,intent(in),optional      :: extrap  !! if true, then extrapolation is allowed
-                                                !! (default is false)
+    integer(ip),intent(out)            :: iflag !! status flag (see [[db2ink]])
+    logical,intent(in),optional        :: extrap !! if true, then extrapolation is allowed
+                                                 !! (default is false)
 
-    integer :: iknot
-    integer :: nx,ny
+    integer(ip) :: iknot
+    integer(ip) :: nx,ny
 
     call me%destroy()
 
-    nx = size(x)
-    ny = size(y)
+    nx = size(x,kind=ip)
+    ny = size(y,kind=ip)
 
     me%nx = nx
     me%ny = ny
@@ -1228,17 +1228,17 @@
     allocate(me%ty(ny+ky))
     allocate(me%bcoef(nx,ny))
     allocate(me%work_val_1(ky))
-    allocate(me%work_val_2(3*max(kx,ky)))
+    allocate(me%work_val_2(3_ip*max(kx,ky)))
 
-    iknot = 0         !knot sequence chosen by db2ink
+    iknot = 0_ip         !knot sequence chosen by db2ink
 
     call db2ink(x,nx,y,ny,fcn,kx,ky,iknot,me%tx,me%ty,me%bcoef,iflag)
 
-    if (iflag==0) then
+    if (iflag==0_ip) then
         call me%set_extrap_flag(extrap)
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_2d_auto_knots
@@ -1259,10 +1259,10 @@
     real(wp),dimension(:,:),intent(in) :: fcn   !! `(nx,ny)` matrix of function values to interpolate.
                                                 !! `fcn(i,j)` should contain the function value at the
                                                 !! point (`x(i)`,`y(j)`)
-    integer,intent(in)                 :: kx    !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)             :: kx    !! The order of spline pieces in \(x\)
                                                 !! ( \( 2 \le k_x < n_x \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                 :: ky    !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)             :: ky    !! The order of spline pieces in \(y\)
                                                 !! ( \( 2 \le k_y < n_y \) )
                                                 !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)   :: tx    !! The `(nx+kx)` knots in the \(x\) direction
@@ -1271,22 +1271,22 @@
     real(wp),dimension(:),intent(in)   :: ty    !! The `(ny+ky)` knots in the \(y\) direction
                                                 !! for the spline interpolant.
                                                 !! Must be non-decreasing.
-    integer,intent(out)                :: iflag !! status flag (see [[db2ink]])
+    integer(ip),intent(out)            :: iflag !! status flag (see [[db2ink]])
     logical,intent(in),optional      :: extrap  !! if true, then extrapolation is allowed
                                                 !! (default is false)
 
-    integer :: nx,ny
+    integer(ip) :: nx,ny
 
     call me%destroy()
 
-    nx = size(x)
-    ny = size(y)
+    nx = size(x,kind=ip)
+    ny = size(y,kind=ip)
 
     call check_knot_vectors_sizes(nx=nx,kx=kx,tx=tx,&
                                   ny=ny,ky=ky,ty=ty,&
                                   iflag=iflag)
 
-    if (iflag == 0) then
+    if (iflag == 0_ip) then
 
         me%nx = nx
         me%ny = ny
@@ -1298,18 +1298,18 @@
         allocate(me%ty(ny+ky))
         allocate(me%bcoef(nx,ny))
         allocate(me%work_val_1(ky))
-        allocate(me%work_val_2(3*max(kx,ky)))
+        allocate(me%work_val_2(3_ip*max(kx,ky)))
 
         me%tx = tx
         me%ty = ty
 
-        call db2ink(x,nx,y,ny,fcn,kx,ky,1,me%tx,me%ty,me%bcoef,iflag)
+        call db2ink(x,nx,y,ny,fcn,kx,ky,1_ip,me%tx,me%ty,me%bcoef,iflag)
 
         call me%set_extrap_flag(extrap)
 
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_2d_specify_knots
@@ -1326,10 +1326,10 @@
     class(bspline_2d),intent(inout) :: me
     real(wp),intent(in)             :: xval  !! \(x\) coordinate of evaluation point.
     real(wp),intent(in)             :: yval  !! \(y\) coordinate of evaluation point.
-    integer,intent(in)              :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idy   !! \(y\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)           :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)           :: idy   !! \(y\) derivative of piecewise polynomial to evaluate.
     real(wp),intent(out)            :: f     !! interpolated value
-    integer,intent(out)             :: iflag !! status flag (see [[db2val]])
+    integer(ip),intent(out)         :: iflag !! status flag (see [[db2val]])
 
     if (me%initialized) then
         call db2val(xval,yval,&
@@ -1342,7 +1342,7 @@
                     me%work_val_1,me%work_val_2,&
                     extrap=me%extrap)
     else
-        iflag = 1
+        iflag = 1_ip
     end if
 
     me%iflag = iflag
@@ -1381,17 +1381,17 @@
     real(wp),dimension(:,:,:),intent(in) :: fcn !! `(nx,ny,nz)` matrix of function values to interpolate.
                                                 !! `fcn(i,j,k)` should contain the function value at the
                                                 !! point (`x(i)`,`y(j)`,`z(k)`)
-    integer,intent(in)                   :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)               :: kx  !! The order of spline pieces in \(x\)
                                                 !! ( \( 2 \le k_x < n_x \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                   :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)               :: ky  !! The order of spline pieces in \(y\)
                                                 !! ( \( 2 \le k_y < n_y \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                   :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)               :: kz  !! The order of spline pieces in \(z\)
                                                 !! ( \( 2 \le k_z < n_z \) )
                                                 !! (order = polynomial degree + 1)
-    logical,intent(in),optional      :: extrap !! if true, then extrapolation is allowed
-                                               !! (default is false)
+    logical,intent(in),optional       :: extrap !! if true, then extrapolation is allowed
+                                                !! (default is false)
 
     call initialize_3d_auto_knots(me,x,y,z,fcn,kx,ky,kz,me%iflag,extrap)
 
@@ -1414,13 +1414,13 @@
     real(wp),dimension(:,:,:),intent(in) :: fcn !! `(nx,ny,nz)` matrix of function values to interpolate.
                                                 !! `fcn(i,j,k)` should contain the function value at the
                                                 !! point (`x(i)`,`y(j)`,`z(k)`)
-    integer,intent(in)                   :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)               :: kx  !! The order of spline pieces in \(x\)
                                                 !! ( \( 2 \le k_x < n_x \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                   :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)               :: ky  !! The order of spline pieces in \(y\)
                                                 !! ( \( 2 \le k_y < n_y \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                   :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)               :: kz  !! The order of spline pieces in \(z\)
                                                 !! ( \( 2 \le k_z < n_z \) )
                                                 !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)     :: tx  !! The `(nx+kx)` knots in the \(x\) direction
@@ -1456,27 +1456,27 @@
     real(wp),dimension(:,:,:),intent(in) :: fcn !! `(nx,ny,nz)` matrix of function values to interpolate.
                                                 !! `fcn(i,j,k)` should contain the function value at the
                                                 !! point (`x(i)`,`y(j)`,`z(k)`)
-    integer,intent(in)                   :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)               :: kx  !! The order of spline pieces in \(x\)
                                                 !! ( \( 2 \le k_x < n_x \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                   :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)               :: ky  !! The order of spline pieces in \(y\)
                                                 !! ( \( 2 \le k_y < n_y \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                   :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)               :: kz  !! The order of spline pieces in \(z\)
                                                 !! ( \( 2 \le k_z < n_z \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(out) :: iflag                !! status flag (see [[db3ink]])
+    integer(ip),intent(out) :: iflag            !! status flag (see [[db3ink]])
     logical,intent(in),optional :: extrap       !! if true, then extrapolation is allowed
                                                 !! (default is false)
 
-    integer :: iknot
-    integer :: nx,ny,nz
+    integer(ip) :: iknot
+    integer(ip) :: nx,ny,nz
 
     call me%destroy()
 
-    nx = size(x)
-    ny = size(y)
-    nz = size(z)
+    nx = size(x,kind=ip)
+    ny = size(y,kind=ip)
+    nz = size(z,kind=ip)
 
     me%nx = nx
     me%ny = ny
@@ -1492,9 +1492,9 @@
     allocate(me%bcoef(nx,ny,nz))
     allocate(me%work_val_1(ky,kz))
     allocate(me%work_val_2(kz))
-    allocate(me%work_val_3(3*max(kx,ky,kz)))
+    allocate(me%work_val_3(3_ip*max(kx,ky,kz)))
 
-    iknot = 0         !knot sequence chosen by db3ink
+    iknot = 0_ip         !knot sequence chosen by db3ink
 
     call db3ink(x,nx,y,ny,z,nz,&
                 fcn,&
@@ -1503,11 +1503,11 @@
                 me%tx,me%ty,me%tz,&
                 me%bcoef,iflag)
 
-    if (iflag==0) then
+    if (iflag==0_ip) then
         call me%set_extrap_flag(extrap)
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_3d_auto_knots
@@ -1529,13 +1529,13 @@
     real(wp),dimension(:,:,:),intent(in) :: fcn !! `(nx,ny,nz)` matrix of function values to interpolate.
                                                 !! `fcn(i,j,k)` should contain the function value at the
                                                 !! point (`x(i)`,`y(j)`,`z(k)`)
-    integer,intent(in)                   :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)               :: kx  !! The order of spline pieces in \(x\)
                                                 !! ( \( 2 \le k_x < n_x \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                   :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)               :: ky  !! The order of spline pieces in \(y\)
                                                 !! ( \( 2 \le k_y < n_y \) )
                                                 !! (order = polynomial degree + 1)
-    integer,intent(in)                   :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)               :: kz  !! The order of spline pieces in \(z\)
                                                 !! ( \( 2 \le k_z < n_z \) )
                                                 !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)     :: tx  !! The `(nx+kx)` knots in the \(x\) direction
@@ -1547,24 +1547,24 @@
     real(wp),dimension(:),intent(in)     :: tz  !! The `(nz+kz)` knots in the \(z\) direction
                                                 !! for the spline interpolant.
                                                 !! Must be non-decreasing.
-    integer,intent(out)  :: iflag               !! status flag (see [[db3ink]])
+    integer(ip),intent(out)  :: iflag               !! status flag (see [[db3ink]])
     logical,intent(in),optional  :: extrap      !! if true, then extrapolation is allowed
                                                 !! (default is false)
 
-    integer :: nx,ny,nz
+    integer(ip) :: nx,ny,nz
 
     call me%destroy()
 
-    nx = size(x)
-    ny = size(y)
-    nz = size(z)
+    nx = size(x,kind=ip)
+    ny = size(y,kind=ip)
+    nz = size(z,kind=ip)
 
     call check_knot_vectors_sizes(nx=nx,kx=kx,tx=tx,&
                                   ny=ny,ky=ky,ty=ty,&
                                   nz=nz,kz=kz,tz=tz,&
                                   iflag=iflag)
 
-    if (iflag == 0) then
+    if (iflag == 0_ip) then
 
         me%nx = nx
         me%ny = ny
@@ -1580,7 +1580,7 @@
         allocate(me%bcoef(nx,ny,nz))
         allocate(me%work_val_1(ky,kz))
         allocate(me%work_val_2(kz))
-        allocate(me%work_val_3(3*max(kx,ky,kz)))
+        allocate(me%work_val_3(3_ip*max(kx,ky,kz)))
 
         me%tx = tx
         me%ty = ty
@@ -1589,7 +1589,7 @@
         call db3ink(x,nx,y,ny,z,nz,&
                     fcn,&
                     kx,ky,kz,&
-                    1,&
+                    1_ip,&
                     me%tx,me%ty,me%tz,&
                     me%bcoef,iflag)
 
@@ -1597,7 +1597,7 @@
 
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_3d_specify_knots
@@ -1615,11 +1615,11 @@
     real(wp),intent(in)             :: xval  !! \(x\) coordinate of evaluation point.
     real(wp),intent(in)             :: yval  !! \(y\) coordinate of evaluation point.
     real(wp),intent(in)             :: zval  !! \(z\) coordinate of evaluation point.
-    integer,intent(in)              :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idy   !! \(y\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idz   !! \(z\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idy   !! \(y\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idz   !! \(z\) derivative of piecewise polynomial to evaluate.
     real(wp),intent(out)            :: f     !! interpolated value
-    integer,intent(out)             :: iflag !! status flag (see [[db3val]])
+    integer(ip),intent(out)         :: iflag !! status flag (see [[db3val]])
 
     if (me%initialized) then
         call db3val(xval,yval,zval,&
@@ -1633,7 +1633,7 @@
                     me%work_val_1,me%work_val_2,me%work_val_3,&
                     extrap=me%extrap)
     else
-        iflag = 1
+        iflag = 1_ip
     end if
 
     me%iflag = iflag
@@ -1673,16 +1673,16 @@
     real(wp),dimension(:,:,:,:),intent(in) :: fcn !! `(nx,ny,nz,nq)` matrix of function values to interpolate.
                                                   !! `fcn(i,j,k,l)` should contain the function value at the
                                                   !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`)
-    integer,intent(in)                     :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                 :: kx  !! The order of spline pieces in \(x\)
                                                   !! ( \( 2 \le k_x < n_x \) )
                                                   !! (order = polynomial degree + 1)
-    integer,intent(in)                     :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                 :: ky  !! The order of spline pieces in \(y\)
                                                   !! ( \( 2 \le k_y < n_y \) )
                                                   !! (order = polynomial degree + 1)
-    integer,intent(in)                     :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                 :: kz  !! The order of spline pieces in \(z\)
                                                   !! ( \( 2 \le k_z < n_z \) )
                                                   !! (order = polynomial degree + 1)
-    integer,intent(in)                     :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                 :: kq  !! The order of spline pieces in \(q\)
                                                   !! ( \( 2 \le k_q < n_q \) )
                                                   !! (order = polynomial degree + 1)
     logical,intent(in),optional      :: extrap    !! if true, then extrapolation is allowed
@@ -1711,16 +1711,16 @@
     real(wp),dimension(:,:,:,:),intent(in)     :: fcn !! `(nx,ny,nz,nq)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                     :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                     :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                     :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)           :: tx  !! The `(nx+kx)` knots in the \(x\) direction
@@ -1760,31 +1760,31 @@
     real(wp),dimension(:,:,:,:),intent(in)     :: fcn !! `(nx,ny,nz,nq)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                     :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                     :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                     :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(out)  :: iflag                     !! status flag (see [[db4ink]])
+    integer(ip),intent(out)  :: iflag                     !! status flag (see [[db4ink]])
     logical,intent(in),optional  :: extrap            !! if true, then extrapolation is allowed
                                                       !! (default is false)
 
-    integer :: iknot
-    integer :: nx,ny,nz,nq
+    integer(ip) :: iknot
+    integer(ip) :: nx,ny,nz,nq
 
     call me%destroy()
 
-    nx = size(x)
-    ny = size(y)
-    nz = size(z)
-    nq = size(q)
+    nx = size(x,kind=ip)
+    ny = size(y,kind=ip)
+    nz = size(z,kind=ip)
+    nq = size(q,kind=ip)
 
     me%nx = nx
     me%ny = ny
@@ -1804,9 +1804,9 @@
     allocate(me%work_val_1(ky,kz,kq))
     allocate(me%work_val_2(kz,kq))
     allocate(me%work_val_3(kq))
-    allocate(me%work_val_4(3*max(kx,ky,kz,kq)))
+    allocate(me%work_val_4(3_ip*max(kx,ky,kz,kq)))
 
-    iknot = 0         !knot sequence chosen by db4ink
+    iknot = 0_ip         !knot sequence chosen by db4ink
 
     call db4ink(x,nx,y,ny,z,nz,q,nq,&
                 fcn,&
@@ -1815,11 +1815,11 @@
                 me%tx,me%ty,me%tz,me%tq,&
                 me%bcoef,iflag)
 
-    if (iflag==0) then
+    if (iflag==0_ip) then
         call me%set_extrap_flag(extrap)
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_4d_auto_knots
@@ -1843,16 +1843,16 @@
     real(wp),dimension(:,:,:,:),intent(in)     :: fcn !! `(nx,ny,nz,nq)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                     :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                     :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                     :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)           :: tx  !! The `(nx+kx)` knots in the \(x\) direction
@@ -1867,18 +1867,18 @@
     real(wp),dimension(:),intent(in)           :: tq  !! The `(nq+kq)` knots in the \(q\) direction
                                                       !! for the spline interpolant.
                                                       !! Must be non-decreasing.
-    integer,intent(out)  :: iflag                     !! status flag (see [[db4ink]])
+    integer(ip),intent(out)  :: iflag                     !! status flag (see [[db4ink]])
     logical,intent(in),optional  :: extrap            !! if true, then extrapolation is allowed
                                                       !! (default is false)
 
-    integer :: nx,ny,nz,nq
+    integer(ip) :: nx,ny,nz,nq
 
     call me%destroy()
 
-    nx = size(x)
-    ny = size(y)
-    nz = size(z)
-    nq = size(q)
+    nx = size(x,kind=ip)
+    ny = size(y,kind=ip)
+    nz = size(z,kind=ip)
+    nq = size(q,kind=ip)
 
     call check_knot_vectors_sizes(nx=nx,kx=kx,tx=tx,&
                                   ny=ny,ky=ky,ty=ty,&
@@ -1886,7 +1886,7 @@
                                   nq=nq,kq=kq,tq=tq,&
                                   iflag=iflag)
 
-    if (iflag == 0) then
+    if (iflag == 0_ip) then
 
         me%nx = nx
         me%ny = ny
@@ -1906,7 +1906,7 @@
         allocate(me%work_val_1(ky,kz,kq))
         allocate(me%work_val_2(kz,kq))
         allocate(me%work_val_3(kq))
-        allocate(me%work_val_4(3*max(kx,ky,kz,kq)))
+        allocate(me%work_val_4(3_ip*max(kx,ky,kz,kq)))
 
         me%tx = tx
         me%ty = ty
@@ -1916,7 +1916,7 @@
         call db4ink(x,nx,y,ny,z,nz,q,nq,&
                     fcn,&
                     kx,ky,kz,kq,&
-                    1,&
+                    1_ip,&
                     me%tx,me%ty,me%tz,me%tq,&
                     me%bcoef,iflag)
 
@@ -1924,7 +1924,7 @@
 
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_4d_specify_knots
@@ -1943,12 +1943,12 @@
     real(wp),intent(in)             :: yval  !! \(y\) coordinate of evaluation point.
     real(wp),intent(in)             :: zval  !! \(z\) coordinate of evaluation point.
     real(wp),intent(in)             :: qval  !! \(q\) coordinate of evaluation point.
-    integer,intent(in)              :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idy   !! \(y\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idz   !! \(z\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idq   !! \(q\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idy   !! \(y\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idz   !! \(z\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idq   !! \(q\) derivative of piecewise polynomial to evaluate.
     real(wp),intent(out)            :: f     !! interpolated value
-    integer,intent(out)             :: iflag !! status flag (see [[db4val]])
+    integer(ip),intent(out)         :: iflag !! status flag (see [[db4val]])
 
     if (me%initialized) then
         call db4val(xval,yval,zval,qval,&
@@ -1962,7 +1962,7 @@
                     me%work_val_1,me%work_val_2,me%work_val_3,me%work_val_4,&
                     extrap=me%extrap)
     else
-        iflag = 1
+        iflag = 1_ip
     end if
 
     me%iflag = iflag
@@ -2003,19 +2003,19 @@
     real(wp),dimension(:,:,:,:,:),intent(in)   :: fcn !! `(nx,ny,nz,nq,nr)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l,m)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`,`r(m)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                     :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                     :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                     :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kr  !! The order of spline pieces in \(r\)
+    integer(ip),intent(in)                     :: kr  !! The order of spline pieces in \(r\)
                                                       !! ( \( 2 \le k_r < n_r \) )
                                                       !! (order = polynomial degree + 1)
     logical,intent(in),optional      :: extrap        !! if true, then extrapolation is allowed
@@ -2046,19 +2046,19 @@
     real(wp),dimension(:,:,:,:,:),intent(in)   :: fcn !! `(nx,ny,nz,nq,nr)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l,m)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`,`r(m)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                     :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                     :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                     :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kr  !! The order of spline pieces in \(r\)
+    integer(ip),intent(in)                     :: kr  !! The order of spline pieces in \(r\)
                                                       !! ( \( 2 \le k_r < n_r \) )
                                                       !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)           :: tx  !! The `(nx+kx)` knots in the \(x\) direction
@@ -2102,35 +2102,35 @@
     real(wp),dimension(:,:,:,:,:),intent(in)   :: fcn !! `(nx,ny,nz,nq,nr)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l,m)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`,`r(m)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                     :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                     :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                     :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kr  !! The order of spline pieces in \(r\)
+    integer(ip),intent(in)                     :: kr  !! The order of spline pieces in \(r\)
                                                       !! ( \( 2 \le k_r < n_r \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(out)  :: iflag                     !! status flag (see [[db5ink]])
+    integer(ip),intent(out)  :: iflag                     !! status flag (see [[db5ink]])
     logical,intent(in),optional  :: extrap            !! if true, then extrapolation is allowed
                                                       !! (default is false)
 
-    integer :: iknot
-    integer :: nx,ny,nz,nq,nr
+    integer(ip) :: iknot
+    integer(ip) :: nx,ny,nz,nq,nr
 
     call me%destroy()
 
-    nx = size(x)
-    ny = size(y)
-    nz = size(z)
-    nq = size(q)
-    nr = size(r)
+    nx = size(x,kind=ip)
+    ny = size(y,kind=ip)
+    nz = size(z,kind=ip)
+    nq = size(q,kind=ip)
+    nr = size(r,kind=ip)
 
     me%nx = nx
     me%ny = ny
@@ -2154,9 +2154,9 @@
     allocate(me%work_val_2(kz,kq,kr))
     allocate(me%work_val_3(kq,kr))
     allocate(me%work_val_4(kr))
-    allocate(me%work_val_5(3*max(kx,ky,kz,kq,kr)))
+    allocate(me%work_val_5(3_ip*max(kx,ky,kz,kq,kr)))
 
-    iknot = 0         !knot sequence chosen by db5ink
+    iknot = 0_ip         !knot sequence chosen by db5ink
 
     call db5ink(x,nx,y,ny,z,nz,q,nq,r,nr,&
                 fcn,&
@@ -2165,11 +2165,11 @@
                 me%tx,me%ty,me%tz,me%tq,me%tr,&
                 me%bcoef,iflag)
 
-    if (iflag==0) then
+    if (iflag==0_ip) then
         call me%set_extrap_flag(extrap)
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_5d_auto_knots
@@ -2195,19 +2195,19 @@
     real(wp),dimension(:,:,:,:,:),intent(in)   :: fcn !! `(nx,ny,nz,nq,nr)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l,m)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`,`r(m)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                     :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                     :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                     :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kr  !! The order of spline pieces in \(r\)
+    integer(ip),intent(in)                     :: kr  !! The order of spline pieces in \(r\)
                                                       !! ( \( 2 \le k_r < n_r \) )
                                                       !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)           :: tx  !! The `(nx+kx)` knots in the \(x\) direction
@@ -2225,19 +2225,19 @@
     real(wp),dimension(:),intent(in)           :: tr  !! The `(nr+kr)` knots in the \(r\) direction
                                                       !! for the spline interpolant.
                                                       !! Must be non-decreasing.
-    integer,intent(out)  :: iflag                     !! status flag (see [[db5ink]])
+    integer(ip),intent(out)  :: iflag                     !! status flag (see [[db5ink]])
     logical,intent(in),optional  :: extrap            !! if true, then extrapolation is allowed
                                                       !! (default is false)
 
-    integer :: nx,ny,nz,nq,nr
+    integer(ip) :: nx,ny,nz,nq,nr
 
     call me%destroy()
 
-    nx = size(x)
-    ny = size(y)
-    nz = size(z)
-    nq = size(q)
-    nr = size(r)
+    nx = size(x,kind=ip)
+    ny = size(y,kind=ip)
+    nz = size(z,kind=ip)
+    nq = size(q,kind=ip)
+    nr = size(r,kind=ip)
 
     call check_knot_vectors_sizes(nx=nx,kx=kx,tx=tx,&
                                   ny=ny,ky=ky,ty=ty,&
@@ -2246,7 +2246,7 @@
                                   nr=nr,kr=kr,tr=tr,&
                                   iflag=iflag)
 
-    if (iflag == 0) then
+    if (iflag == 0_ip) then
 
         me%nx = nx
         me%ny = ny
@@ -2270,7 +2270,7 @@
         allocate(me%work_val_2(kz,kq,kr))
         allocate(me%work_val_3(kq,kr))
         allocate(me%work_val_4(kr))
-        allocate(me%work_val_5(3*max(kx,ky,kz,kq,kr)))
+        allocate(me%work_val_5(3_ip*max(kx,ky,kz,kq,kr)))
 
         me%tx = tx
         me%ty = ty
@@ -2281,7 +2281,7 @@
         call db5ink(x,nx,y,ny,z,nz,q,nq,r,nr,&
                     fcn,&
                     kx,ky,kz,kq,kr,&
-                    1,&
+                    1_ip,&
                     me%tx,me%ty,me%tz,me%tq,me%tr,&
                     me%bcoef,iflag)
 
@@ -2289,7 +2289,7 @@
 
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_5d_specify_knots
@@ -2309,13 +2309,13 @@
     real(wp),intent(in)             :: zval  !! \(z\) coordinate of evaluation point.
     real(wp),intent(in)             :: qval  !! \(q\) coordinate of evaluation point.
     real(wp),intent(in)             :: rval  !! \(r\) coordinate of evaluation point.
-    integer,intent(in)              :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idy   !! \(y\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idz   !! \(z\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idq   !! \(q\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idr   !! \(r\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idy   !! \(y\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idz   !! \(z\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idq   !! \(q\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idr   !! \(r\) derivative of piecewise polynomial to evaluate.
     real(wp),intent(out)            :: f     !! interpolated value
-    integer,intent(out)             :: iflag !! status flag (see [[db5val]])
+    integer(ip),intent(out)         :: iflag !! status flag (see [[db5val]])
 
     if (me%initialized) then
         call db5val(xval,yval,zval,qval,rval,&
@@ -2329,7 +2329,7 @@
                     me%work_val_1,me%work_val_2,me%work_val_3,me%work_val_4,me%work_val_5,&
                     extrap=me%extrap)
     else
-        iflag = 1
+        iflag = 1_ip
     end if
 
     me%iflag = iflag
@@ -2372,22 +2372,22 @@
     real(wp),dimension(:,:,:,:,:,:),intent(in) :: fcn !! `(nx,ny,nz,nq,nr,ns)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l,m,n)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`,`r(m)`,`s(n)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                      :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                      :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                      :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                      :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kr  !! The order of spline pieces in \(r\)
+    integer(ip),intent(in)                      :: kr  !! The order of spline pieces in \(r\)
                                                       !! ( \( 2 \le k_r < n_r \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ks  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                      :: ks  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
     logical,intent(in),optional      :: extrap        !! if true, then extrapolation is allowed
@@ -2419,22 +2419,22 @@
     real(wp),dimension(:,:,:,:,:,:),intent(in) :: fcn !! `(nx,ny,nz,nq,nr,ns)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l,m,n)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`,`r(m)`,`s(n)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                     :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                     :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                     :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kr  !! The order of spline pieces in \(r\)
+    integer(ip),intent(in)                     :: kr  !! The order of spline pieces in \(r\)
                                                       !! ( \( 2 \le k_r < n_r \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ks  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: ks  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)           :: tx  !! The `(nx+kx)` knots in the \(x\) direction
@@ -2485,39 +2485,39 @@
     real(wp),dimension(:,:,:,:,:,:),intent(in) :: fcn !! `(nx,ny,nz,nq,nr,ns)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l,m,n)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`,`r(m)`,`s(n)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                     :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                     :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                     :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kr  !! The order of spline pieces in \(r\)
+    integer(ip),intent(in)                     :: kr  !! The order of spline pieces in \(r\)
                                                       !! ( \( 2 \le k_r < n_r \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ks  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: ks  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(out)  :: iflag                     !! status flag (see [[db6ink]])
+    integer(ip),intent(out)  :: iflag                     !! status flag (see [[db6ink]])
     logical,intent(in),optional  :: extrap            !! if true, then extrapolation is allowed
                                                       !! (default is false)
 
-    integer :: iknot
-    integer :: nx,ny,nz,nq,nr,ns
+    integer(ip) :: iknot
+    integer(ip) :: nx,ny,nz,nq,nr,ns
 
     call me%destroy()
 
-    nx = size(x)
-    ny = size(y)
-    nz = size(z)
-    nq = size(q)
-    nr = size(r)
-    ns = size(s)
+    nx = size(x,kind=ip)
+    ny = size(y,kind=ip)
+    nz = size(z,kind=ip)
+    nq = size(q,kind=ip)
+    nr = size(r,kind=ip)
+    ns = size(s,kind=ip)
 
     me%nx = nx
     me%ny = ny
@@ -2545,9 +2545,9 @@
     allocate(me%work_val_3(kq,kr,ks))
     allocate(me%work_val_4(kr,ks))
     allocate(me%work_val_5(ks))
-    allocate(me%work_val_6(3*max(kx,ky,kz,kq,kr,ks)))
+    allocate(me%work_val_6(3_ip*max(kx,ky,kz,kq,kr,ks)))
 
-    iknot = 0         !knot sequence chosen by db6ink
+    iknot = 0_ip         !knot sequence chosen by db6ink
 
     call db6ink(x,nx,y,ny,z,nz,q,nq,r,nr,s,ns,&
                 fcn,&
@@ -2556,11 +2556,11 @@
                 me%tx,me%ty,me%tz,me%tq,me%tr,me%ts,&
                 me%bcoef,iflag)
 
-    if (iflag==0) then
+    if (iflag==0_ip) then
         call me%set_extrap_flag(extrap)
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_6d_auto_knots
@@ -2587,22 +2587,22 @@
     real(wp),dimension(:,:,:,:,:,:),intent(in) :: fcn !! `(nx,ny,nz,nq,nr,ns)` matrix of function values to interpolate.
                                                       !! `fcn(i,j,k,l,m,n)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`,`r(m)`,`s(n)`)
-    integer,intent(in)                         :: kx  !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                     :: kx  !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ky  !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                     :: ky  !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kz  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: kz  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kq  !! The order of spline pieces in \(q\)
+    integer(ip),intent(in)                     :: kq  !! The order of spline pieces in \(q\)
                                                       !! ( \( 2 \le k_q < n_q \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: kr  !! The order of spline pieces in \(r\)
+    integer(ip),intent(in)                     :: kr  !! The order of spline pieces in \(r\)
                                                       !! ( \( 2 \le k_r < n_r \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                         :: ks  !! The order of spline pieces in \(z\)
+    integer(ip),intent(in)                     :: ks  !! The order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)           :: tx  !! The `(nx+kx)` knots in the \(x\) direction
@@ -2623,20 +2623,20 @@
     real(wp),dimension(:),intent(in)           :: ts  !! The `(ns+ks)` knots in the \(s\) direction
                                                       !! for the spline interpolant.
                                                       !! Must be non-decreasing.
-    integer,intent(out)  :: iflag                     !! status flag (see [[db6ink]])
+    integer(ip),intent(out)  :: iflag                     !! status flag (see [[db6ink]])
     logical,intent(in),optional  :: extrap            !! if true, then extrapolation is allowed
                                                       !! (default is false)
 
-    integer :: nx,ny,nz,nq,nr,ns
+    integer(ip) :: nx,ny,nz,nq,nr,ns
 
     call me%destroy()
 
-    nx = size(x)
-    ny = size(y)
-    nz = size(z)
-    nq = size(q)
-    nr = size(r)
-    ns = size(s)
+    nx = size(x,kind=ip)
+    ny = size(y,kind=ip)
+    nz = size(z,kind=ip)
+    nq = size(q,kind=ip)
+    nr = size(r,kind=ip)
+    ns = size(s,kind=ip)
 
     call check_knot_vectors_sizes(nx=nx,kx=kx,tx=tx,&
                                   ny=ny,ky=ky,ty=ty,&
@@ -2646,7 +2646,7 @@
                                   ns=ns,ks=ks,ts=ts,&
                                   iflag=iflag)
 
-    if (iflag == 0) then
+    if (iflag == 0_ip) then
 
         me%nx = nx
         me%ny = ny
@@ -2674,7 +2674,7 @@
         allocate(me%work_val_3(kq,kr,ks))
         allocate(me%work_val_4(kr,ks))
         allocate(me%work_val_5(ks))
-        allocate(me%work_val_6(3*max(kx,ky,kz,kq,kr,ks)))
+        allocate(me%work_val_6(3_ip*max(kx,ky,kz,kq,kr,ks)))
 
         me%tx = tx
         me%ty = ty
@@ -2686,7 +2686,7 @@
         call db6ink(x,nx,y,ny,z,nz,q,nq,r,nr,s,ns,&
                     fcn,&
                     kx,ky,kz,kq,kr,ks,&
-                    1,&
+                    1_ip,&
                     me%tx,me%ty,me%tz,me%tq,me%tr,me%ts,&
                     me%bcoef,iflag)
 
@@ -2694,7 +2694,7 @@
 
     end if
 
-    me%initialized = iflag==0
+    me%initialized = iflag==0_ip
     me%iflag = iflag
 
     end subroutine initialize_6d_specify_knots
@@ -2715,14 +2715,14 @@
     real(wp),intent(in)             :: qval  !! \(q\) coordinate of evaluation point.
     real(wp),intent(in)             :: rval  !! \(r\) coordinate of evaluation point.
     real(wp),intent(in)             :: sval  !! \(s\) coordinate of evaluation point.
-    integer,intent(in)              :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idy   !! \(y\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idz   !! \(z\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idq   !! \(q\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: idr   !! \(r\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)              :: ids   !! \(s\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idx   !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idy   !! \(y\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idz   !! \(z\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idq   !! \(q\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: idr   !! \(r\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)          :: ids   !! \(s\) derivative of piecewise polynomial to evaluate.
     real(wp),intent(out)            :: f     !! interpolated value
-    integer,intent(out)             :: iflag !! status flag (see [[db6val]])
+    integer(ip),intent(out)         :: iflag !! status flag (see [[db6val]])
 
     if (me%initialized) then
         call db6val(xval,yval,zval,qval,rval,sval,&
@@ -2736,7 +2736,7 @@
                     me%work_val_1,me%work_val_2,me%work_val_3,me%work_val_4,me%work_val_5,me%work_val_6,&
                     extrap=me%extrap)
     else
-        iflag = 1
+        iflag = 1_ip
     end if
 
     me%iflag = iflag
@@ -2757,61 +2757,61 @@
 
     implicit none
 
-    integer,intent(in),optional               :: nx
-    integer,intent(in),optional               :: ny
-    integer,intent(in),optional               :: nz
-    integer,intent(in),optional               :: nq
-    integer,intent(in),optional               :: nr
-    integer,intent(in),optional               :: ns
-    integer,intent(in),optional               :: kx
-    integer,intent(in),optional               :: ky
-    integer,intent(in),optional               :: kz
-    integer,intent(in),optional               :: kq
-    integer,intent(in),optional               :: kr
-    integer,intent(in),optional               :: ks
+    integer(ip),intent(in),optional           :: nx
+    integer(ip),intent(in),optional           :: ny
+    integer(ip),intent(in),optional           :: nz
+    integer(ip),intent(in),optional           :: nq
+    integer(ip),intent(in),optional           :: nr
+    integer(ip),intent(in),optional           :: ns
+    integer(ip),intent(in),optional           :: kx
+    integer(ip),intent(in),optional           :: ky
+    integer(ip),intent(in),optional           :: kz
+    integer(ip),intent(in),optional           :: kq
+    integer(ip),intent(in),optional           :: kr
+    integer(ip),intent(in),optional           :: ks
     real(wp),dimension(:),intent(in),optional :: tx
     real(wp),dimension(:),intent(in),optional :: ty
     real(wp),dimension(:),intent(in),optional :: tz
     real(wp),dimension(:),intent(in),optional :: tq
     real(wp),dimension(:),intent(in),optional :: tr
     real(wp),dimension(:),intent(in),optional :: ts
-    integer,intent(out)                       :: iflag  !! 0 if everything is OK
+    integer(ip),intent(out)                   :: iflag  !! 0 if everything is OK
 
-    iflag = 0
+    iflag = 0_ip
 
     if (present(nx) .and. present(kx) .and. present(tx)) then
-        if (size(tx)/=(nx+kx)) then
-            iflag = 501  ! tx is not the correct size (nx+kx)
+        if (size(tx,kind=ip)/=(nx+kx)) then
+            iflag = 501_ip  ! tx is not the correct size (nx+kx)
         end if
     end if
 
     if (present(ny) .and. present(ky) .and. present(ty)) then
-        if (size(ty)/=(ny+ky)) then
-            iflag = 502  ! ty is not the correct size (ny+ky)
+        if (size(ty,kind=ip)/=(ny+ky)) then
+            iflag = 502_ip  ! ty is not the correct size (ny+ky)
         end if
     end if
 
     if (present(nz) .and. present(kz) .and. present(tz)) then
-        if (size(tz)/=(nz+kz)) then
-            iflag = 503  ! tz is not the correct size (nz+kz)
+        if (size(tz,kind=ip)/=(nz+kz)) then
+            iflag = 503_ip  ! tz is not the correct size (nz+kz)
         end if
     end if
 
     if (present(nq) .and. present(kq) .and. present(tq)) then
-        if (size(tq)/=(nq+kq)) then
-            iflag = 504  ! tq is not the correct size (nq+kq)
+        if (size(tq,kind=ip)/=(nq+kq)) then
+            iflag = 504_ip  ! tq is not the correct size (nq+kq)
         end if
     end if
 
     if (present(nr) .and. present(kr) .and. present(tr)) then
-        if (size(tr)/=(nr+kr)) then
-            iflag = 505  ! tr is not the correct size (nr+kr)
+        if (size(tr,kind=ip)/=(nr+kr)) then
+            iflag = 505_ip  ! tr is not the correct size (nr+kr)
         end if
     end if
 
     if (present(ns) .and. present(ks) .and. present(ts)) then
-        if (size(ts)/=(ns+ks)) then
-            iflag = 506  ! ts is not the correct size (ns+ks)
+        if (size(ts,kind=ip)/=(ns+ks)) then
+            iflag = 506_ip  ! ts is not the correct size (ns+ks)
         end if
     end if
 

--- a/src/bspline_sub_module.f90
+++ b/src/bspline_sub_module.f90
@@ -186,7 +186,7 @@
 !### History
 !  * Jacob Williams, 10/30/2015 : Created 1D routine.
 
-    pure subroutine db1val(xval,idx,tx,nx,kx,bcoef,f,iflag,inbvx,work,extrap)
+    pure subroutine db1val(xval,idx,tx,nx,kx,bcoef,f,iflag,inbvx,w0,extrap)
 
     implicit none
 
@@ -207,7 +207,7 @@
     integer,intent(inout)                :: inbvx    !! initialization parameter which must be set
                                                      !! to 1 the first time this routine is called,
                                                      !! and must not be changed by the user.
-    real(wp),dimension(3*kx),intent(inout) :: work   !! work array
+    real(wp),dimension(3*kx),intent(inout) :: w0     !! work array
     logical,intent(in),optional          :: extrap   !! if extrapolation is allowed
                                                      !! (if not present, default is False)
 
@@ -215,7 +215,7 @@
 
     iflag = check_value(xval,tx,1,extrap); if (iflag/=0) return
 
-    call dbvalu(tx,bcoef,nx,kx,idx,xval,inbvx,work,iflag,f,extrap)
+    call dbvalu(tx,bcoef,nx,kx,idx,xval,inbvx,w0,iflag,f,extrap)
 
     end subroutine db1val
 !*****************************************************************************************
@@ -230,7 +230,7 @@
 !### See also
 !  * [[dbsqad]] -- the core routine.
 
-    pure subroutine db1sqad(tx,bcoef,nx,kx,x1,x2,f,iflag,work)
+    pure subroutine db1sqad(tx,bcoef,nx,kx,x1,x2,f,iflag,w0)
 
     implicit none
 
@@ -245,9 +245,9 @@
                                                     !!
                                                     !! * \( = 0 \)   : no errors
                                                     !! * \( \ne 0 \) : error
-    real(wp),dimension(3*kx),intent(inout) :: work  !! work array for [[dbsqad]]
+    real(wp),dimension(3*kx),intent(inout) :: w0    !! work array for [[dbsqad]]
 
-    call dbsqad(tx,bcoef,nx,kx,x1,x2,f,work,iflag)
+    call dbsqad(tx,bcoef,nx,kx,x1,x2,f,w0,iflag)
 
     end subroutine db1sqad
 !*****************************************************************************************
@@ -266,7 +266,7 @@
 !@note This one is not pure, because we are not enforcing
 !      that the user function `fun` be pure.
 
-    subroutine db1fqad(fun,tx,bcoef,nx,kx,idx,x1,x2,tol,f,iflag,work)
+    subroutine db1fqad(fun,tx,bcoef,nx,kx,idx,x1,x2,tol,f,iflag,w0)
 
     implicit none
 
@@ -289,9 +289,9 @@
                                                   !!
                                                   !! * \( = 0 \)   : no errors
                                                   !! * \( \ne 0 \) : error
-    real(wp),dimension(3*kx),intent(inout) :: work !! work array for [[dbfqad]]
+    real(wp),dimension(3*kx),intent(inout) :: w0  !! work array for [[dbfqad]]
 
-    call dbfqad(fun,tx,bcoef,nx,kx,idx,x1,x2,tol,f,iflag,work)
+    call dbfqad(fun,tx,bcoef,nx,kx,idx,x1,x2,tol,f,iflag,w0)
 
     end subroutine db1fqad
 !*****************************************************************************************
@@ -474,7 +474,7 @@
 !  * JEC : 000330 modified array declarations.
 !  * Jacob Williams, 2/24/2015 : extensive refactoring of CMLIB routine.
 
-    pure subroutine db2val(xval,yval,idx,idy,tx,ty,nx,ny,kx,ky,bcoef,f,iflag,inbvx,inbvy,iloy,temp,work,extrap)
+    pure subroutine db2val(xval,yval,idx,idy,tx,ty,nx,ny,kx,ky,bcoef,f,iflag,inbvx,inbvy,iloy,w1,w0,extrap)
 
     implicit none
 
@@ -511,8 +511,8 @@
     integer,intent(inout)                :: iloy     !! initialization parameter which must be set to 1
                                                      !! the first time this routine is called,
                                                      !! and must not be changed by the user.
-    real(wp),dimension(ky),intent(inout) :: temp !! work array
-    real(wp),dimension(3*max(kx,ky)),intent(inout) :: work !! work array
+    real(wp),dimension(ky),intent(inout)           :: w1 !! work array
+    real(wp),dimension(3*max(kx,ky)),intent(inout) :: w0 !! work array
     logical,intent(in),optional          :: extrap   !! if extrapolation is allowed
                                                      !! (if not present, default is False)
 
@@ -528,12 +528,12 @@
     kcol = lefty - ky
     do k=1,ky
         kcol = kcol + 1
-        call dbvalu(tx,bcoef(:,kcol),nx,kx,idx,xval,inbvx,work,iflag,temp(k),extrap)
+        call dbvalu(tx,bcoef(:,kcol),nx,kx,idx,xval,inbvx,w0,iflag,w1(k),extrap)
         if (iflag/=0) return !error
     end do
 
     kcol = lefty - ky + 1
-    call dbvalu(ty(kcol:),temp,ky,ky,idy,yval,inbvy,work,iflag,f,extrap)
+    call dbvalu(ty(kcol:),w1,ky,ky,idy,yval,inbvy,w0,iflag,f,extrap)
 
     end subroutine db2val
 !*****************************************************************************************
@@ -752,7 +752,7 @@
     pure subroutine db3val(xval,yval,zval,idx,idy,idz,&
                            tx,ty,tz,&
                            nx,ny,nz,kx,ky,kz,bcoef,f,iflag,&
-                           inbvx,inbvy,inbvz,iloy,iloz,temp1,temp2,work,extrap)
+                           inbvx,inbvy,inbvz,iloy,iloz,w2,w1,w0,extrap)
 
     implicit none
 
@@ -801,9 +801,9 @@
     integer,intent(inout)                   :: iloz     !! initialization parameter which must be
                                                         !! set to 1 the first time this routine is called,
                                                         !! and must not be changed by the user.
-    real(wp),dimension(ky,kz),intent(inout)             :: temp1    !! work array
-    real(wp),dimension(kz),intent(inout)                :: temp2    !! work array
-    real(wp),dimension(3*max(kx,ky,kz)),intent(inout)   :: work     !! work array
+    real(wp),dimension(ky,kz),intent(inout)           :: w2  !! work array
+    real(wp),dimension(kz),intent(inout)              :: w1  !! work array
+    real(wp),dimension(3*max(kx,ky,kz)),intent(inout) :: w0  !! work array
     logical,intent(in),optional             :: extrap   !! if extrapolation is allowed
                                                         !! (if not present, default is False)
 
@@ -826,19 +826,19 @@
         kcoly = lefty - ky
         do j=1,ky
             kcoly = kcoly + 1
-            call dbvalu(tx,bcoef(:,kcoly,kcolz),nx,kx,idx,xval,inbvx,work,iflag,temp1(j,k),extrap)
+            call dbvalu(tx,bcoef(:,kcoly,kcolz),nx,kx,idx,xval,inbvx,w0,iflag,w2(j,k),extrap)
             if (iflag/=0) return
         end do
     end do
 
     kcoly = lefty - ky + 1
     do k=1,kz
-        call dbvalu(ty(kcoly:),temp1(:,k),ky,ky,idy,yval,inbvy,work,iflag,temp2(k),extrap)
+        call dbvalu(ty(kcoly:),w2(:,k),ky,ky,idy,yval,inbvy,w0,iflag,w1(k),extrap)
         if (iflag/=0) return
     end do
 
     kcolz = leftz - kz + 1
-    call dbvalu(tz(kcolz:),temp2,kz,kz,idz,zval,inbvz,work,iflag,f,extrap)
+    call dbvalu(tz(kcolz:),w1,kz,kz,idz,zval,inbvz,w0,iflag,f,extrap)
 
     end subroutine db3val
 !*****************************************************************************************
@@ -1024,7 +1024,7 @@
                                 kx,ky,kz,kq,&
                                 bcoef,f,iflag,&
                                 inbvx,inbvy,inbvz,inbvq,&
-                                iloy,iloz,iloq,temp1,temp2,temp3,work,extrap)
+                                iloy,iloz,iloq,w3,w2,w1,w0,extrap)
 
     implicit none
 
@@ -1091,10 +1091,10 @@
     integer,intent(inout)                      :: iloq     !! initialization parameter which must be set
                                                            !! to 1 the first time this routine is called,
                                                            !! and must not be changed by the user.
-    real(wp),dimension(ky,kz,kq),intent(inout)           :: temp1 !! work array
-    real(wp),dimension(kz,kq),intent(inout)              :: temp2 !! work array
-    real(wp),dimension(kq),intent(inout)                 :: temp3 !! work array
-    real(wp),dimension(3*max(kx,ky,kz,kq)),intent(inout) :: work  !! work array
+    real(wp),dimension(ky,kz,kq),intent(inout)           :: w3 !! work array
+    real(wp),dimension(kz,kq),intent(inout)              :: w2 !! work array
+    real(wp),dimension(kq),intent(inout)                 :: w1 !! work array
+    real(wp),dimension(3*max(kx,ky,kz,kq)),intent(inout) :: w0 !! work array
     logical,intent(in),optional                :: extrap   !! if extrapolation is allowed
                                                            !! (if not present, default is False)
 
@@ -1125,8 +1125,8 @@
             do j=1,ky
                 kcoly = kcoly + 1
                 call dbvalu(tx,bcoef(:,kcoly,kcolz,kcolq),&
-                                     nx,kx,idx,xval,inbvx,work,iflag,&
-                                     temp1(j,k,q),extrap)
+                                     nx,kx,idx,xval,inbvx,w0,iflag,&
+                                     w3(j,k,q),extrap)
                 if (iflag/=0) return
             end do
         end do
@@ -1136,9 +1136,9 @@
     kcoly = lefty - ky + 1
     do q=1,kq
         do k=1,kz
-            call dbvalu(ty(kcoly:),temp1(:,k,q),&
-                        ky,ky,idy,yval,inbvy,work,iflag,&
-                        temp2(k,q),extrap)
+            call dbvalu(ty(kcoly:),w3(:,k,q),&
+                        ky,ky,idy,yval,inbvy,w0,iflag,&
+                        w2(k,q),extrap)
             if (iflag/=0) return
         end do
     end do
@@ -1146,15 +1146,15 @@
     ! z -> q
     kcolz = leftz - kz + 1
     do q=1,kq
-        call dbvalu(tz(kcolz:),temp2(:,q),&
-                    kz,kz,idz,zval,inbvz,work,iflag,&
-                    temp3(q),extrap)
+        call dbvalu(tz(kcolz:),w2(:,q),&
+                    kz,kz,idz,zval,inbvz,w0,iflag,&
+                    w1(q),extrap)
         if (iflag/=0) return
     end do
 
     ! q
     kcolq = leftq - kq + 1
-    call dbvalu(tq(kcolq:),temp3,kq,kq,idq,qval,inbvq,work,iflag,f,extrap)
+    call dbvalu(tq(kcolq:),w1,kq,kq,idq,qval,inbvq,w0,iflag,f,extrap)
 
     end subroutine db4val
 !*****************************************************************************************
@@ -1371,7 +1371,7 @@
                                 bcoef,f,iflag,&
                                 inbvx,inbvy,inbvz,inbvq,inbvr,&
                                 iloy,iloz,iloq,ilor,&
-                                temp1,temp2,temp3,temp4,work,extrap)
+                                w4,w3,w2,w1,w0,extrap)
 
     implicit none
 
@@ -1453,11 +1453,11 @@
     integer,intent(inout)                         :: ilor     !! initialization parameter which must be set
                                                               !! to 1 the first time this routine is called,
                                                               !! and must not be changed by the user.
-    real(wp),dimension(ky,kz,kq,kr),intent(inout) :: temp1  !! work array
-    real(wp),dimension(kz,kq,kr),intent(inout)    :: temp2  !! work array
-    real(wp),dimension(kq,kr),intent(inout)       :: temp3  !! work array
-    real(wp),dimension(kr),intent(inout)          :: temp4  !! work array
-    real(wp),dimension(3*max(kx,ky,kz,kq,kr)),intent(inout)  :: work  !! work array
+    real(wp),dimension(ky,kz,kq,kr),intent(inout)           :: w4  !! work array
+    real(wp),dimension(kz,kq,kr),intent(inout)              :: w3  !! work array
+    real(wp),dimension(kq,kr),intent(inout)                 :: w2  !! work array
+    real(wp),dimension(kr),intent(inout)                    :: w1  !! work array
+    real(wp),dimension(3*max(kx,ky,kz,kq,kr)),intent(inout) :: w0  !! work array
     logical,intent(in),optional                   :: extrap   !! if extrapolation is allowed
                                                               !! (if not present, default is False)
 
@@ -1493,7 +1493,7 @@
                 do j=1,ky
                     kcoly = kcoly + 1
                     call dbvalu(tx,bcoef(:,kcoly,kcolz,kcolq,kcolr),&
-                                nx,kx,idx,xval,inbvx,work,iflag,temp1(j,k,q,r),&
+                                nx,kx,idx,xval,inbvx,w0,iflag,w4(j,k,q,r),&
                                 extrap)
                     if (iflag/=0) return
                 end do
@@ -1506,8 +1506,8 @@
     do r=1,kr
         do q=1,kq
             do k=1,kz
-                call dbvalu(ty(kcoly:),temp1(:,k,q,r),ky,ky,idy,yval,inbvy,&
-                            work,iflag,temp2(k,q,r),extrap)
+                call dbvalu(ty(kcoly:),w4(:,k,q,r),ky,ky,idy,yval,inbvy,&
+                            w0,iflag,w3(k,q,r),extrap)
                 if (iflag/=0) return
             end do
         end do
@@ -1517,8 +1517,8 @@
     kcolz = leftz - kz + 1
     do r=1,kr
         do q=1,kq
-            call dbvalu(tz(kcolz:),temp2(:,q,r),kz,kz,idz,zval,inbvz,&
-                        work,iflag,temp3(q,r),extrap)
+            call dbvalu(tz(kcolz:),w3(:,q,r),kz,kz,idz,zval,inbvz,&
+                        w0,iflag,w2(q,r),extrap)
             if (iflag/=0) return
         end do
     end do
@@ -1526,14 +1526,14 @@
     ! q -> r
     kcolq = leftq - kq + 1
     do r=1,kr
-        call dbvalu(tq(kcolq:),temp3(:,r),kq,kq,idq,qval,inbvq,&
-                    work,iflag,temp4(r),extrap)
+        call dbvalu(tq(kcolq:),w2(:,r),kq,kq,idq,qval,inbvq,&
+                    w0,iflag,w1(r),extrap)
         if (iflag/=0) return
     end do
 
     ! r
     kcolr = leftr - kr + 1
-    call dbvalu(tr(kcolr:),temp4,kr,kr,idr,rval,inbvr,work,iflag,f,extrap)
+    call dbvalu(tr(kcolr:),w1,kr,kr,idr,rval,inbvr,w0,iflag,f,extrap)
 
     end subroutine db5val
 !*****************************************************************************************
@@ -1775,7 +1775,7 @@
                                 bcoef,f,iflag,&
                                 inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,&
                                 iloy,iloz,iloq,ilor,ilos,&
-                                temp1,temp2,temp3,temp4,temp5,work,extrap)
+                                w5,w4,w3,w2,w1,w0,extrap)
 
     implicit none
 
@@ -1872,15 +1872,14 @@
     integer,intent(inout)                            :: ilos     !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    real(wp),dimension(ky,kz,kq,kr,ks),intent(inout)   :: temp1 !! work array
-    real(wp),dimension(kz,kq,kr,ks),intent(inout)      :: temp2 !! work array
-    real(wp),dimension(kq,kr,ks),intent(inout)         :: temp3 !! work array
-    real(wp),dimension(kr,ks),intent(inout)            :: temp4 !! work array
-    real(wp),dimension(ks),intent(inout)               :: temp5 !! work array
-    real(wp),dimension(3*max(kx,ky,kz,kq,kr,ks)),intent(inout) :: work !! work array
+    real(wp),dimension(ky,kz,kq,kr,ks),intent(inout)           :: w5 !! work array
+    real(wp),dimension(kz,kq,kr,ks),intent(inout)              :: w4 !! work array
+    real(wp),dimension(kq,kr,ks),intent(inout)                 :: w3 !! work array
+    real(wp),dimension(kr,ks),intent(inout)                    :: w2 !! work array
+    real(wp),dimension(ks),intent(inout)                       :: w1 !! work array
+    real(wp),dimension(3*max(kx,ky,kz,kq,kr,ks)),intent(inout) :: w0 !! work array
     logical,intent(in),optional                      :: extrap   !! if extrapolation is allowed
                                                                  !! (if not present, default is False)
-
 
     integer :: lefty,leftz,leftq,leftr,lefts,&
                kcoly,kcolz,kcolq,kcolr,kcols,&
@@ -1920,8 +1919,8 @@
                     do j=1,ky
                         kcoly = kcoly + 1
                         call dbvalu(tx,bcoef(:,kcoly,kcolz,kcolq,kcolr,kcols),&
-                                             nx,kx,idx,xval,inbvx,work,iflag,&
-                                             temp1(j,k,q,r,s),extrap)
+                                             nx,kx,idx,xval,inbvx,w0,iflag,&
+                                             w5(j,k,q,r,s),extrap)
                         if (iflag/=0) return
                     end do
                 end do
@@ -1935,9 +1934,9 @@
         do r=1,kr
             do q=1,kq
                 do k=1,kz
-                    call dbvalu(ty(kcoly:),temp1(:,k,q,r,s),&
-                                ky,ky,idy,yval,inbvy,work,iflag,&
-                                temp2(k,q,r,s),extrap)
+                    call dbvalu(ty(kcoly:),w5(:,k,q,r,s),&
+                                ky,ky,idy,yval,inbvy,w0,iflag,&
+                                w4(k,q,r,s),extrap)
                     if (iflag/=0) return
                 end do
             end do
@@ -1949,9 +1948,9 @@
     do s=1,ks
         do r=1,kr
             do q=1,kq
-                call dbvalu(tz(kcolz:),temp2(:,q,r,s),&
-                            kz,kz,idz,zval,inbvz,work,iflag,&
-                            temp3(q,r,s),extrap)
+                call dbvalu(tz(kcolz:),w4(:,q,r,s),&
+                            kz,kz,idz,zval,inbvz,w0,iflag,&
+                            w3(q,r,s),extrap)
                 if (iflag/=0) return
             end do
         end do
@@ -1961,9 +1960,9 @@
     kcolq = leftq - kq + 1
     do s=1,ks
         do r=1,kr
-            call dbvalu(tq(kcolq:),temp3(:,r,s),&
-                        kq,kq,idq,qval,inbvq,work,iflag,&
-                        temp4(r,s),extrap)
+            call dbvalu(tq(kcolq:),w3(:,r,s),&
+                        kq,kq,idq,qval,inbvq,w0,iflag,&
+                        w2(r,s),extrap)
             if (iflag/=0) return
         end do
     end do
@@ -1971,15 +1970,15 @@
     ! r -> s
     kcolr = leftr - kr + 1
     do s=1,ks
-        call dbvalu(tr(kcolr:),temp4(:,s),&
-                    kr,kr,idr,rval,inbvr,work,iflag,&
-                    temp5(s),extrap)
+        call dbvalu(tr(kcolr:),w2(:,s),&
+                    kr,kr,idr,rval,inbvr,w0,iflag,&
+                    w1(s),extrap)
         if (iflag/=0) return
     end do
 
     ! s
     kcols = lefts - ks + 1
-    call dbvalu(ts(kcols:),temp5,ks,ks,ids,sval,inbvs,work,iflag,f,extrap)
+    call dbvalu(ts(kcols:),w1,ks,ks,ids,sval,inbvs,w0,iflag,f,extrap)
 
     end subroutine db6val
 !*****************************************************************************************

--- a/src/bspline_sub_module.f90
+++ b/src/bspline_sub_module.f90
@@ -670,6 +670,7 @@
     logical :: status_ok
     real(wp),dimension(:),allocatable :: temp !! work array of length `nx*ny*nz`
     real(wp),dimension(:),allocatable :: work !! work array of length `max(2*kx*(nx+1),2*ky*(ny+1),2*kz*(nz+1))`
+    integer :: i, j, k, ii !! counter
 
     ! check validity of input
 
@@ -696,7 +697,18 @@
         allocate(work(max(2*kx*(nx+1),2*ky*(ny+1),2*kz*(nz+1))))
 
         ! copy fcn to work in packed for dbtpcf
-        temp(1:nx*ny*nz) = reshape( fcn, [nx*ny*nz] )
+        !temp = reshape( fcn, [nx*ny*nz] )
+        ! replaced with loops to avoid stack
+        ! overflow for large data set:
+        ii = 0
+        do k = 1, nz
+            do j = 1, ny
+                do i = 1, nx
+                    ii = ii + 1
+                    temp(ii) = fcn(i,j,k)
+                end do
+            end do
+        end do
 
         ! construct b-spline coefficients
                       call dbtpcf(x,nx,temp, nx,ny*nz,tx,kx,bcoef,work,iflag)
@@ -1304,6 +1316,7 @@
     real(wp),dimension(:),allocatable :: temp !! work array of length `nx*ny*nz*nq*nr`
     real(wp),dimension(:),allocatable :: work !! work array of length `max(2*kx*(nx+1),
                                               !! 2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1),2*kr*(nr+1))`
+    integer :: i, j, k, l, m, ii !! counter
 
     !  check validity of input
     call check_inputs(  iknot,&
@@ -1331,7 +1344,22 @@
         allocate(work(max(2*kx*(nx+1),2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1),2*kr*(nr+1))))
 
         ! copy fcn to work in packed for dbtpcf
-        temp(1:nx*ny*nz*nq*nr) = reshape( fcn, [nx*ny*nz*nq*nr] )
+        !temp(1:nx*ny*nz*nq*nr) = reshape( fcn, [nx*ny*nz*nq*nr] )
+        ! replaced with loops to avoid stack
+        ! overflow for large data set:
+        ii = 0
+        do m = 1, nr
+            do l = 1, nq
+                do k = 1, nz
+                    do j = 1, ny
+                        do i = 1, nx
+                            ii = ii + 1
+                            temp(ii) = fcn(i,j,k,l,m)
+                        end do
+                    end do
+                end do
+            end do
+        end do
 
         !  construct b-spline coefficients
                       call dbtpcf(x,nx,temp,  nx,ny*nz*nq*nr,tx,kx,bcoef,work,iflag)
@@ -1343,7 +1371,7 @@
         deallocate(temp)
         deallocate(work)
 
-     end if
+    end if
 
     end subroutine db5ink
 !*****************************************************************************************

--- a/src/bspline_sub_module.f90
+++ b/src/bspline_sub_module.f90
@@ -2160,12 +2160,16 @@
         integer,intent(out)                       :: iflag !! status return code
         logical,intent(out)                       :: error !! true if there was an error
 
+        integer,dimension(:),allocatable :: itmp !! temp integer array
+
         if (present(n) .and. present(k) .and. present(x) .and. present(t)) then
-            call check_n('n'//s,n,x,[ierrs(1),ierrs(5)],iflag,error); if (error) return
+            itmp = [ierrs(1),ierrs(5)]
+            call check_n('n'//s,n,x,itmp,iflag,error); if (error) return
             call check_k('k'//s,k,n,ierrs(2),iflag,error); if (error) return
             call check_x(s,n,x,ierrs(3),iflag,error); if (error) return
             if (iknot /= 0) then
-                call check_t('t'//s,n,k,t,[ierrs(4),ierrs(6)],iflag,error); if (error) return
+                itmp = [ierrs(4),ierrs(6)]
+                call check_t('t'//s,n,k,t,itmp,iflag,error); if (error) return
             end if
         end if
 

--- a/src/bspline_sub_module.f90
+++ b/src/bspline_sub_module.f90
@@ -2193,7 +2193,7 @@
         integer(ip),intent(out)                   :: iflag !! status return code
         logical,intent(out)                       :: error !! true if there was an error
 
-        integer(ip),dimension(:),allocatable :: itmp !! temp integer array
+        integer(ip),dimension(2) :: itmp !! temp integer array
 
         if (present(n) .and. present(k) .and. present(x) .and. present(t)) then
             itmp = [ierrs(1_ip),ierrs(5)]
@@ -2328,9 +2328,9 @@
 
     implicit none
 
-    integer(ip),intent(in)             :: n
+    integer(ip),intent(in)             :: n  !! dimension of `x`
     integer(ip),intent(in)             :: k
-    real(wp),dimension(n),intent(in)   :: x
+    real(wp),dimension(:),intent(in)   :: x
     real(wp),dimension(:),intent(out)  :: t
 
     integer(ip) :: i, j, ipj, npj, ip1, jstrt
@@ -2389,13 +2389,13 @@
 
     pure subroutine dbtpcf(x,n,fcn,ldf,nf,t,k,bcoef,work,iflag)
 
-    integer(ip),intent(in)                :: n
+    integer(ip),intent(in)                :: n  !! dimension of `x`
     integer(ip),intent(in)                :: nf
     integer(ip),intent(in)                :: ldf
     integer(ip),intent(in)                :: k
-    real(wp),dimension(n),intent(in)      :: x
+    real(wp),dimension(:),intent(in)      :: x
     real(wp),dimension(ldf,nf),intent(in) :: fcn
-    real(wp),dimension(*),intent(in)      :: t
+    real(wp),dimension(:),intent(in)      :: t
     real(wp),dimension(nf,n),intent(out)  :: bcoef
     real(wp),dimension(*),intent(out)     :: work   !! work array of size >= `2*k*(n+1)`
     integer(ip),intent(out)               :: iflag  !!   0: no errors
@@ -3183,7 +3183,7 @@
     implicit none
 
     integer(ip),intent(in)             :: lxt    !! length of the `xt` vector
-    real(wp),dimension(lxt),intent(in) :: xt     !! a knot or break point vector of length `lxt`
+    real(wp),dimension(:),intent(in)   :: xt     !! a knot or break point vector of length `lxt`
     real(wp),intent(in)                :: xx     !! argument
     integer(ip),intent(inout)          :: ilo    !! an initialization parameter which must be set
                                                  !! to 1 the first time the spline array `xt` is

--- a/src/bspline_sub_module.f90
+++ b/src/bspline_sub_module.f90
@@ -40,7 +40,7 @@
 
     module bspline_sub_module
 
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
     use,intrinsic :: iso_fortran_env, only: error_unit
 
     implicit none
@@ -59,10 +59,10 @@
     public :: b1fqad_func
 
     !Spline function order (order = polynomial degree + 1)
-    integer,parameter,public :: bspline_order_quadratic = 3
-    integer,parameter,public :: bspline_order_cubic     = 4
-    integer,parameter,public :: bspline_order_quartic   = 5
-    integer,parameter,public :: bspline_order_quintic   = 6
+    integer(ip),parameter,public :: bspline_order_quadratic = 3_ip
+    integer(ip),parameter,public :: bspline_order_cubic     = 4_ip
+    integer(ip),parameter,public :: bspline_order_quartic   = 5_ip
+    integer(ip),parameter,public :: bspline_order_quintic   = 6_ip
 
     !main routines:
     public :: db1ink, db1val, db1sqad, db1fqad
@@ -92,14 +92,14 @@
 
     implicit none
 
-    integer,intent(in)                      :: nx     !! Number of \(x\) abcissae
-    integer,intent(in)                      :: kx     !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                  :: nx     !! Number of \(x\) abcissae
+    integer(ip),intent(in)                  :: kx     !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)        :: x      !! `(nx)` array of \(x\) abcissae. Must be strictly increasing.
     real(wp),dimension(:),intent(in)        :: fcn    !! `(nx)` array of function values to interpolate. `fcn(i)` should
                                                       !! contain the function value at the point `x(i)`
-    integer,intent(in)                      :: iknot  !! knot sequence flag:
+    integer(ip),intent(in)                  :: iknot  !! knot sequence flag:
                                                       !!
                                                       !! * 0 = knot sequence chosen by [[db1ink]].
                                                       !! * 1 = knot sequence chosen by user.
@@ -111,7 +111,7 @@
                                                       !!
                                                       !! Must be non-decreasing.
     real(wp),dimension(:),intent(out)       :: bcoef  !! `(nx)` array of coefficients of the b-spline interpolant.
-    integer,intent(out)                     :: iflag  !! status flag:
+    integer(ip),intent(out)                 :: iflag  !! status flag:
                                                       !!
                                                       !! * 0 = successful execution.
                                                       !! * 2 = `iknot` out of range.
@@ -142,14 +142,14 @@
     if (status_ok) then
 
         !choose knots
-        if (iknot == 0) then
+        if (iknot == 0_ip) then
             call dbknot(x,nx,kx,tx)
         end if
 
-        allocate(work(2*kx*(nx+1)))
+        allocate(work(2_ip*kx*(nx+1_ip)))
 
         !construct b-spline coefficients
-        call dbtpcf(x,nx,fcn,nx,1,tx,kx,bcoef,work,iflag)
+        call dbtpcf(x,nx,fcn,nx,1_ip,tx,kx,bcoef,work,iflag)
 
         deallocate(work)
 
@@ -169,11 +169,11 @@
 !
 !  [[db1val]] returns 0.0 if (`xval`,`yval`) is out of range. that is, if
 !```fortran
-!   xval < tx(1) .or. xval > tx(nx+kx)
+!   xval < tx(1_ip) .or. xval > tx(nx+kx)
 !```
 !  if the knots `tx` were chosen by [[db1ink]], then this is equivalent to:
 !```fortran
-!   xval < x(1) .or. xval > x(nx)+epsx
+!   xval < x(1_ip) .or. xval > x(nx)+epsx
 !```
 !  where
 !```fortran
@@ -190,30 +190,30 @@
 
     implicit none
 
-    integer,intent(in)                   :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                   :: nx       !! the number of interpolation points in \(x\).
+    integer(ip),intent(in)               :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)               :: nx       !! the number of interpolation points in \(x\).
                                                      !! (same as in last call to [[db1ink]])
-    integer,intent(in)                   :: kx       !! order of polynomial pieces in \(x\).
+    integer(ip),intent(in)               :: kx       !! order of polynomial pieces in \(x\).
                                                      !! (same as in last call to [[db1ink]])
     real(wp),intent(in)                  :: xval     !! \(x\) coordinate of evaluation point.
     real(wp),dimension(nx+kx),intent(in) :: tx       !! sequence of knots defining the piecewise polynomial
                                                      !! in the \(x\) direction. (same as in last call to [[db1ink]])
     real(wp),dimension(nx),intent(in)    :: bcoef    !! the b-spline coefficients computed by [[db1ink]].
     real(wp),intent(out)                 :: f        !! interpolated value
-    integer,intent(out)                  :: iflag    !! status flag:
+    integer(ip),intent(out)              :: iflag    !! status flag:
                                                      !!
                                                      !! * \( = 0 \)   : no errors
                                                      !! * \( \ne 0 \) : error
-    integer,intent(inout)                :: inbvx    !! initialization parameter which must be set
+    integer(ip),intent(inout)            :: inbvx    !! initialization parameter which must be set
                                                      !! to 1 the first time this routine is called,
                                                      !! and must not be changed by the user.
-    real(wp),dimension(3*kx),intent(inout) :: w0     !! work array
+    real(wp),dimension(3_ip*kx),intent(inout) :: w0  !! work array
     logical,intent(in),optional          :: extrap   !! if extrapolation is allowed
                                                      !! (if not present, default is False)
 
     f = 0.0_wp
 
-    iflag = check_value(xval,tx,1,extrap); if (iflag/=0) return
+    iflag = check_value(xval,tx,1_ip,extrap); if (iflag/=0_ip) return
 
     call dbvalu(tx,bcoef,nx,kx,idx,xval,inbvx,w0,iflag,f,extrap)
 
@@ -234,14 +234,14 @@
 
     implicit none
 
-    integer,intent(in)                   :: nx      !! length of coefficient array
-    integer,intent(in)                   :: kx      !! order of b-spline, `1 <= k <= 20`
+    integer(ip),intent(in)               :: nx      !! length of coefficient array
+    integer(ip),intent(in)               :: kx      !! order of b-spline, `1 <= k <= 20`
     real(wp),dimension(nx+kx),intent(in) :: tx      !! knot array
     real(wp),dimension(nx),intent(in)    :: bcoef   !! b-spline coefficient array
     real(wp),intent(in)                  :: x1      !! left point of quadrature interval in `t(kx) <= x <= t(nx+1)`
     real(wp),intent(in)                  :: x2      !! right point of quadrature interval in `t(kx) <= x <= t(nx+1)`
     real(wp),intent(out)                 :: f       !! integral of the b-spline over (`x1`,`x2`)
-    integer,intent(out)                  :: iflag   !! status flag:
+    integer(ip),intent(out)              :: iflag   !! status flag:
                                                     !!
                                                     !! * \( = 0 \)   : no errors
                                                     !! * \( \ne 0 \) : error
@@ -258,7 +258,7 @@
 !  function `fun` and the `idx`-th derivative of a `kx`-th order b-spline,
 !  using the b-representation `(tx,bcoef,nx,kx)`, with an adaptive
 !  8-point Legendre-Gauss algorithm.
-!  `(x1,x2)` must be a subinterval of `t(kx) <= x <= t(nx+1)`.
+!  `(x1,x2)` must be a subinterval of `t(kx) <= x <= t(nx+1_ip)`.
 !
 !### See also
 !  * [[dbfqad]] -- the core routine.
@@ -272,11 +272,11 @@
 
     procedure(b1fqad_func)              :: fun    !! external function of one argument for the
                                                   !! integrand `bf(x)=fun(x)*dbvalu(tx,bcoef,nx,kx,id,x,inbv,work)`
-    integer,intent(in)                  :: nx     !! length of coefficient array
-    integer,intent(in)                  :: kx     !! order of b-spline, `kx >= 1`
+    integer(ip),intent(in)              :: nx     !! length of coefficient array
+    integer(ip),intent(in)              :: kx     !! order of b-spline, `kx >= 1`
     real(wp),dimension(nx+kx),intent(in):: tx     !! knot array
     real(wp),dimension(nx),intent(in)   :: bcoef  !! b-spline coefficient array
-    integer,intent(in)                  :: idx    !! order of the spline derivative, `0 <= idx <= k-1`
+    integer(ip),intent(in)              :: idx    !! order of the spline derivative, `0 <= idx <= k-1`
                                                   !! `idx=0` gives the spline function
     real(wp),intent(in)                 :: x1     !! left point of quadrature interval in `t(k) <= x <= t(n+1)`
     real(wp),intent(in)                 :: x2     !! right point of quadrature interval in `t(k) <= x <= t(n+1)`
@@ -285,11 +285,11 @@
                                                   !! of `1.0e-300` and real(wp) unit roundoff for
                                                   !! the machine
     real(wp),intent(out)                :: f      !! integral of `bf(x)` on `(x1,x2)`
-    integer,intent(out)                 :: iflag  !! status flag:
+    integer(ip),intent(out)             :: iflag  !! status flag:
                                                   !!
                                                   !! * \( = 0 \)   : no errors
                                                   !! * \( \ne 0 \) : error
-    real(wp),dimension(3*kx),intent(inout) :: w0  !! work array for [[dbfqad]]
+    real(wp),dimension(3_ip*kx),intent(inout) :: w0  !! work array for [[dbfqad]]
 
     call dbfqad(fun,tx,bcoef,nx,kx,idx,x1,x2,tol,f,iflag,w0)
 
@@ -300,7 +300,7 @@
 !>
 !  Determines the parameters of a function that interpolates
 !  the two-dimensional gridded data
-!  $$ [x(i),y(j),\mathrm{fcn}(i,j)] ~\mathrm{for}~ i=1,..,n_x ~\mathrm{and}~ j=1,..,n_y $$
+!  $$ [x(i),y(j),\mathrm{fcn}(i,j)] ~\mathrm{for}~ i=1_ip,..,n_x ~\mathrm{and}~ j=1_ip,..,n_y $$
 !  The interpolating function and its derivatives may
 !  subsequently be evaluated by the function [[db2val]].
 !
@@ -313,7 +313,7 @@
 !  where the functions \(u_i\) and \(v_j\) are one-dimensional b-spline
 !  basis functions. the coefficients \( a_{ij} \) are chosen so that
 !
-!  $$ s(x(i),y(j)) = \mathrm{fcn}(i,j) ~\mathrm{for}~ i=1,..,n_x ~\mathrm{and}~ j=1,..,n_y $$
+!  $$ s(x(i),y(j)) = \mathrm{fcn}(i,j) ~\mathrm{for}~ i=1_ip,..,n_x ~\mathrm{and}~ j=1_ip,..,n_y $$
 !
 !  Note that for each fixed value of \(y\), \( s(x,y) \) is a piecewise
 !  polynomial function of \(x\) alone, and for each fixed value of \(x\), \( s(x,y) \)
@@ -350,12 +350,12 @@
 
     implicit none
 
-    integer,intent(in)                      :: nx     !! Number of \(x\) abcissae
-    integer,intent(in)                      :: ny     !! Number of \(y\) abcissae
-    integer,intent(in)                      :: kx     !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                  :: nx     !! Number of \(x\) abcissae
+    integer(ip),intent(in)                  :: ny     !! Number of \(y\) abcissae
+    integer(ip),intent(in)                  :: kx     !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                      :: ky     !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                  :: ky     !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)        :: x      !! `(nx)` array of \(x\) abcissae. Must be strictly increasing.
@@ -363,7 +363,7 @@
     real(wp),dimension(:,:),intent(in)      :: fcn    !! `(nx,ny)` matrix of function values to interpolate.
                                                       !! `fcn(i,j)` should contain the function value at the
                                                       !! point (`x(i)`,`y(j)`)
-    integer,intent(in)                      :: iknot  !! knot sequence flag:
+    integer(ip),intent(in)                  :: iknot  !! knot sequence flag:
                                                       !!
                                                       !! * 0 = knot sequence chosen by [[db1ink]].
                                                       !! * 1 = knot sequence chosen by user.
@@ -382,7 +382,7 @@
                                                       !!
                                                       !! Must be non-decreasing.
     real(wp),dimension(:,:),intent(out)     :: bcoef  !! `(nx,ny)` matrix of coefficients of the b-spline interpolant.
-    integer,intent(out)                     :: iflag  !! *  0 = successful execution.
+    integer(ip),intent(out)                 :: iflag  !! *  0 = successful execution.
                                                       !! *  2 = `iknot` out of range.
                                                       !! *  3 = `nx` out of range.
                                                       !! *  4 = `kx` out of range.
@@ -403,7 +403,7 @@
 
     logical :: status_ok
     real(wp),dimension(:),allocatable :: temp !! work array of length `nx*ny`
-    real(wp),dimension(:),allocatable :: work !! work array of length `max(2*kx*(nx+1),2*ky*(ny+1))`
+    real(wp),dimension(:),allocatable :: work !! work array of length `max(2_ip*kx*(nx+1_ip),2_ip*ky*(ny+1_ip))`
 
     !check validity of inputs
 
@@ -420,17 +420,17 @@
     if (status_ok) then
 
         !choose knots
-        if (iknot == 0) then
+        if (iknot == 0_ip) then
             call dbknot(x,nx,kx,tx)
             call dbknot(y,ny,ky,ty)
         end if
 
         allocate(temp(nx*ny))
-        allocate(work(max(2*kx*(nx+1),2*ky*(ny+1))))
+        allocate(work(max(2_ip*kx*(nx+1_ip),2_ip*ky*(ny+1_ip))))
 
         !construct b-spline coefficients
-                      call dbtpcf(x,nx,fcn, nx,ny,tx,kx,temp, work,iflag)
-        if (iflag==0) call dbtpcf(y,ny,temp,ny,nx,ty,ky,bcoef,work,iflag)
+                         call dbtpcf(x,nx,fcn, nx,ny,tx,kx,temp, work,iflag)
+        if (iflag==0_ip) call dbtpcf(y,ny,temp,ny,nx,ty,ky,bcoef,work,iflag)
 
         deallocate(temp)
         deallocate(work)
@@ -448,17 +448,17 @@
 !
 !  To evaluate the interpolant
 !  itself, set `idx=idy=0`, to evaluate the first partial with respect
-!  to `x`, set `idx=1,idy=0`, and so on.
+!  to `x`, set `idx=1_ip,idy=0`, and so on.
 !
 !  [[db2val]] returns 0.0 if `(xval,yval)` is out of range. that is, if
 !```fortran
-!   xval < tx(1) .or. xval > tx(nx+kx) .or.
-!   yval < ty(1) .or. yval > ty(ny+ky)
+!   xval < tx(1_ip) .or. xval > tx(nx+kx) .or.
+!   yval < ty(1_ip) .or. yval > ty(ny+ky)
 !```
 !  if the knots tx and ty were chosen by [[db2ink]], then this is equivalent to:
 !```fortran
-!   xval < x(1) .or. xval > x(nx)+epsx .or.
-!   yval < y(1) .or. yval > y(ny)+epsy
+!   xval < x(1_ip) .or. xval > x(nx)+epsx .or.
+!   yval < y(1_ip) .or. yval > y(ny)+epsy
 !```
 !  where
 !```fortran
@@ -478,15 +478,15 @@
 
     implicit none
 
-    integer,intent(in)                   :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                   :: idy      !! \(y\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                   :: nx       !! the number of interpolation points in \(x\).
+    integer(ip),intent(in)               :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)               :: idy      !! \(y\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)               :: nx       !! the number of interpolation points in \(x\).
                                                      !! (same as in last call to [[db2ink]])
-    integer,intent(in)                   :: ny       !! the number of interpolation points in \(y\).
+    integer(ip),intent(in)               :: ny       !! the number of interpolation points in \(y\).
                                                      !! (same as in last call to [[db2ink]])
-    integer,intent(in)                   :: kx       !! order of polynomial pieces in \(x\).
+    integer(ip),intent(in)               :: kx       !! order of polynomial pieces in \(x\).
                                                      !! (same as in last call to [[db2ink]])
-    integer,intent(in)                   :: ky       !! order of polynomial pieces in \(y\).
+    integer(ip),intent(in)               :: ky       !! order of polynomial pieces in \(y\).
                                                      !! (same as in last call to [[db2ink]])
     real(wp),intent(in)                  :: xval     !! \(x\) coordinate of evaluation point.
     real(wp),intent(in)                  :: yval     !! \(y\) coordinate of evaluation point.
@@ -498,41 +498,41 @@
                                                      !! (same as in last call to [[db2ink]])
     real(wp),dimension(nx,ny),intent(in) :: bcoef    !! the b-spline coefficients computed by [[db2ink]].
     real(wp),intent(out)                 :: f        !! interpolated value
-    integer,intent(out)                  :: iflag    !! status flag:
+    integer(ip),intent(out)              :: iflag    !! status flag:
                                                      !!
                                                      !! * \( = 0 \)   : no errors
                                                      !! * \( \ne 0 \) : error
-    integer,intent(inout)                :: inbvx    !! initialization parameter which must be set to 1
+    integer(ip),intent(inout)            :: inbvx    !! initialization parameter which must be set to 1
                                                      !! the first time this routine is called,
                                                      !! and must not be changed by the user.
-    integer,intent(inout)                :: inbvy    !! initialization parameter which must be set to 1
+    integer(ip),intent(inout)            :: inbvy    !! initialization parameter which must be set to 1
                                                      !! the first time this routine is called,
                                                      !! and must not be changed by the user.
-    integer,intent(inout)                :: iloy     !! initialization parameter which must be set to 1
+    integer(ip),intent(inout)            :: iloy     !! initialization parameter which must be set to 1
                                                      !! the first time this routine is called,
                                                      !! and must not be changed by the user.
-    real(wp),dimension(ky),intent(inout)           :: w1 !! work array
-    real(wp),dimension(3*max(kx,ky)),intent(inout) :: w0 !! work array
+    real(wp),dimension(ky),intent(inout)              :: w1 !! work array
+    real(wp),dimension(3_ip*max(kx,ky)),intent(inout) :: w0 !! work array
     logical,intent(in),optional          :: extrap   !! if extrapolation is allowed
                                                      !! (if not present, default is False)
 
-    integer :: k, lefty, kcol
+    integer(ip) :: k, lefty, kcol
 
     f = 0.0_wp
 
-    iflag = check_value(xval,tx,1,extrap); if (iflag/=0) return
-    iflag = check_value(yval,ty,2,extrap); if (iflag/=0) return
+    iflag = check_value(xval,tx,1_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(yval,ty,2_ip,extrap); if (iflag/=0_ip) return
 
-    call dintrv(ty,ny+ky,yval,iloy,lefty,iflag,extrap); if (iflag/=0) return
+    call dintrv(ty,ny+ky,yval,iloy,lefty,iflag,extrap); if (iflag/=0_ip) return
 
     kcol = lefty - ky
-    do k=1,ky
-        kcol = kcol + 1
+    do k=1_ip,ky
+        kcol = kcol + 1_ip
         call dbvalu(tx,bcoef(:,kcol),nx,kx,idx,xval,inbvx,w0,iflag,w1(k),extrap)
-        if (iflag/=0) return !error
+        if (iflag/=0_ip) return !error
     end do
 
-    kcol = lefty - ky + 1
+    kcol = lefty - ky + 1_ip
     call dbvalu(ty(kcol:),w1,ky,ky,idy,yval,inbvy,w0,iflag,f,extrap)
 
     end subroutine db2val
@@ -597,16 +597,16 @@
 
     implicit none
 
-    integer,intent(in)                       :: nx    !! number of \(x\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                       :: ny    !! number of \(y\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                       :: nz    !! number of \(z\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                       :: kx    !! The order of spline pieces in \(x\)
+    integer(ip),intent(in)                   :: nx    !! number of \(x\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                   :: ny    !! number of \(y\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                   :: nz    !! number of \(z\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                   :: kx    !! The order of spline pieces in \(x\)
                                                       !! ( \( 2 \le k_x < n_x \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                       :: ky    !! The order of spline pieces in \(y\)
+    integer(ip),intent(in)                   :: ky    !! The order of spline pieces in \(y\)
                                                       !! ( \( 2 \le k_y < n_y \) )
                                                       !! (order = polynomial degree + 1)
-    integer,intent(in)                       :: kz    !! the order of spline pieces in \(z\)
+    integer(ip),intent(in)                   :: kz    !! the order of spline pieces in \(z\)
                                                       !! ( \( 2 \le k_z < n_z \) )
                                                       !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)         :: x     !! `(nx)` array of \(x\) abcissae. must be strictly increasing.
@@ -614,7 +614,7 @@
     real(wp),dimension(:),intent(in)         :: z     !! `(nz)` array of \(z\) abcissae. must be strictly increasing.
     real(wp),dimension(:,:,:),intent(in)     :: fcn   !! `(nx,ny,nz)` matrix of function values to interpolate. `fcn(i,j,k)` should
                                                       !! contain the function value at the point (`x(i)`,`y(j)`,`z(k)`)
-    integer,intent(in)                       :: iknot !! knot sequence flag:
+    integer(ip),intent(in)                   :: iknot !! knot sequence flag:
                                                       !!
                                                       !! * 0 = knot sequence chosen by [[db3ink]].
                                                       !! * 1 = knot sequence chosen by user.
@@ -640,7 +640,7 @@
                                                       !!
                                                       !! Must be non-decreasing.
     real(wp),dimension(:,:,:),intent(out)    :: bcoef !! `(nx,ny,nz)` matrix of coefficients of the b-spline interpolant.
-    integer,intent(out)                      :: iflag !! *  0 = successful execution.
+    integer(ip),intent(out)                  :: iflag !! *  0 = successful execution.
                                                       !! *  2 = `iknot` out of range.
                                                       !! *  3 = `nx` out of range.
                                                       !! *  4 = `kx` out of range.
@@ -669,8 +669,9 @@
 
     logical :: status_ok
     real(wp),dimension(:),allocatable :: temp !! work array of length `nx*ny*nz`
-    real(wp),dimension(:),allocatable :: work !! work array of length `max(2*kx*(nx+1),2*ky*(ny+1),2*kz*(nz+1))`
-    integer :: i, j, k, ii !! counter
+    real(wp),dimension(:),allocatable :: work !! work array of length `max(2*kx*(nx+1),
+                                              !! 2*ky*(ny+1),2*kz*(nz+1))`
+    integer(ip) :: i, j, k, ii !! counter
 
     ! check validity of input
 
@@ -687,33 +688,33 @@
     if (status_ok) then
 
         ! choose knots
-        if (iknot == 0) then
+        if (iknot == 0_ip) then
             call dbknot(x,nx,kx,tx)
             call dbknot(y,ny,ky,ty)
             call dbknot(z,nz,kz,tz)
         end if
 
         allocate(temp(nx*ny*nz))
-        allocate(work(max(2*kx*(nx+1),2*ky*(ny+1),2*kz*(nz+1))))
+        allocate(work(max(2_ip*kx*(nx+1_ip),2_ip*ky*(ny+1_ip),2_ip*kz*(nz+1_ip))))
 
         ! copy fcn to work in packed for dbtpcf
         !temp = reshape( fcn, [nx*ny*nz] )
         ! replaced with loops to avoid stack
         ! overflow for large data set:
-        ii = 0
-        do k = 1, nz
-            do j = 1, ny
-                do i = 1, nx
-                    ii = ii + 1
+        ii = 0_ip
+        do k = 1_ip, nz
+            do j = 1_ip, ny
+                do i = 1_ip, nx
+                    ii = ii + 1_ip
                     temp(ii) = fcn(i,j,k)
                 end do
             end do
         end do
 
         ! construct b-spline coefficients
-                      call dbtpcf(x,nx,temp, nx,ny*nz,tx,kx,bcoef,work,iflag)
-        if (iflag==0) call dbtpcf(y,ny,bcoef,ny,nx*nz,ty,ky,temp, work,iflag)
-        if (iflag==0) call dbtpcf(z,nz,temp, nz,nx*ny,tz,kz,bcoef,work,iflag)
+                         call dbtpcf(x,nx,temp, nx,ny*nz,tx,kx,bcoef,work,iflag)
+        if (iflag==0_ip) call dbtpcf(y,ny,bcoef,ny,nx*nz,ty,ky,temp, work,iflag)
+        if (iflag==0_ip) call dbtpcf(z,nz,temp, nz,nx*ny,tz,kz,bcoef,work,iflag)
 
         deallocate(temp)
         deallocate(work)
@@ -768,20 +769,20 @@
 
     implicit none
 
-    integer,intent(in)                      :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                      :: idy      !! \(y\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                      :: idz      !! \(z\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                      :: nx       !! the number of interpolation points in \(x\).
+    integer(ip),intent(in)                  :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                  :: idy      !! \(y\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                  :: idz      !! \(z\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                  :: nx       !! the number of interpolation points in \(x\).
                                                         !! (same as in last call to [[db3ink]])
-    integer,intent(in)                      :: ny       !! the number of interpolation points in \(y\).
+    integer(ip),intent(in)                  :: ny       !! the number of interpolation points in \(y\).
                                                         !! (same as in last call to [[db3ink]])
-    integer,intent(in)                      :: nz       !! the number of interpolation points in \(z\).
+    integer(ip),intent(in)                  :: nz       !! the number of interpolation points in \(z\).
                                                         !! (same as in last call to [[db3ink]])
-    integer,intent(in)                      :: kx       !! order of polynomial pieces in \(z\).
+    integer(ip),intent(in)                  :: kx       !! order of polynomial pieces in \(z\).
                                                         !! (same as in last call to [[db3ink]])
-    integer,intent(in)                      :: ky       !! order of polynomial pieces in \(y\).
+    integer(ip),intent(in)                  :: ky       !! order of polynomial pieces in \(y\).
                                                         !! (same as in last call to [[db3ink]])
-    integer,intent(in)                      :: kz       !! order of polynomial pieces in \(z\).
+    integer(ip),intent(in)                  :: kz       !! order of polynomial pieces in \(z\).
                                                         !! (same as in last call to [[db3ink]])
     real(wp),intent(in)                     :: xval     !! \(x\) coordinate of evaluation point.
     real(wp),intent(in)                     :: yval     !! \(y\) coordinate of evaluation point.
@@ -794,62 +795,62 @@
                                                         !! in the \(z\) direction. (same as in last call to [[db3ink]])
     real(wp),dimension(nx,ny,nz),intent(in) :: bcoef    !! the b-spline coefficients computed by [[db3ink]].
     real(wp),intent(out)                    :: f        !! interpolated value
-    integer,intent(out)                     :: iflag    !! status flag:
+    integer(ip),intent(out)                 :: iflag    !! status flag:
                                                         !!
                                                         !! * \( = 0 \)   : no errors
                                                         !! * \( \ne 0 \) : error
-    integer,intent(inout)                   :: inbvx    !! initialization parameter which must be
+    integer(ip),intent(inout)               :: inbvx    !! initialization parameter which must be
                                                         !! set to 1 the first time this routine is called,
                                                         !! and must not be changed by the user.
-    integer,intent(inout)                   :: inbvy    !! initialization parameter which must be
+    integer(ip),intent(inout)               :: inbvy    !! initialization parameter which must be
                                                         !! set to 1 the first time this routine is called,
                                                         !! and must not be changed by the user.
-    integer,intent(inout)                   :: inbvz    !! initialization parameter which must be
+    integer(ip),intent(inout)               :: inbvz    !! initialization parameter which must be
                                                         !! set to 1 the first time this routine is called,
                                                         !! and must not be changed by the user.
-    integer,intent(inout)                   :: iloy     !! initialization parameter which must be
+    integer(ip),intent(inout)               :: iloy     !! initialization parameter which must be
                                                         !! set to 1 the first time this routine is called,
                                                         !! and must not be changed by the user.
-    integer,intent(inout)                   :: iloz     !! initialization parameter which must be
+    integer(ip),intent(inout)               :: iloz     !! initialization parameter which must be
                                                         !! set to 1 the first time this routine is called,
                                                         !! and must not be changed by the user.
-    real(wp),dimension(ky,kz),intent(inout)           :: w2  !! work array
-    real(wp),dimension(kz),intent(inout)              :: w1  !! work array
-    real(wp),dimension(3*max(kx,ky,kz)),intent(inout) :: w0  !! work array
+    real(wp),dimension(ky,kz),intent(inout)              :: w2  !! work array
+    real(wp),dimension(kz),intent(inout)                 :: w1  !! work array
+    real(wp),dimension(3_ip*max(kx,ky,kz)),intent(inout) :: w0  !! work array
     logical,intent(in),optional             :: extrap   !! if extrapolation is allowed
                                                         !! (if not present, default is False)
 
-    integer :: lefty, leftz, kcoly, kcolz, j, k
+    integer(ip) :: lefty, leftz, kcoly, kcolz, j, k
 
     f = 0.0_wp
 
-    iflag = check_value(xval,tx,1,extrap); if (iflag/=0) return
-    iflag = check_value(yval,ty,2,extrap); if (iflag/=0) return
-    iflag = check_value(zval,tz,3,extrap); if (iflag/=0) return
+    iflag = check_value(xval,tx,1_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(yval,ty,2_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(zval,tz,3_ip,extrap); if (iflag/=0_ip) return
 
-    call dintrv(ty,ny+ky,yval,iloy,lefty,iflag,extrap); if (iflag/=0) return
-    call dintrv(tz,nz+kz,zval,iloz,leftz,iflag,extrap); if (iflag/=0) return
+    call dintrv(ty,ny+ky,yval,iloy,lefty,iflag,extrap); if (iflag/=0_ip) return
+    call dintrv(tz,nz+kz,zval,iloz,leftz,iflag,extrap); if (iflag/=0_ip) return
 
-    iflag = 0
+    iflag = 0_ip
 
     kcolz = leftz - kz
-    do k=1,kz
-        kcolz = kcolz + 1
+    do k=1_ip,kz
+        kcolz = kcolz + 1_ip
         kcoly = lefty - ky
-        do j=1,ky
-            kcoly = kcoly + 1
+        do j=1_ip,ky
+            kcoly = kcoly + 1_ip
             call dbvalu(tx,bcoef(:,kcoly,kcolz),nx,kx,idx,xval,inbvx,w0,iflag,w2(j,k),extrap)
-            if (iflag/=0) return
+            if (iflag/=0_ip) return
         end do
     end do
 
-    kcoly = lefty - ky + 1
-    do k=1,kz
+    kcoly = lefty - ky + 1_ip
+    do k=1_ip,kz
         call dbvalu(ty(kcoly:),w2(:,k),ky,ky,idy,yval,inbvy,w0,iflag,w1(k),extrap)
-        if (iflag/=0) return
+        if (iflag/=0_ip) return
     end do
 
-    kcolz = leftz - kz + 1
+    kcolz = leftz - kz + 1_ip
     call dbvalu(tz(kcolz:),w1,kz,kz,idz,zval,inbvz,w0,iflag,f,extrap)
 
     end subroutine db3val
@@ -860,8 +861,8 @@
 !  Determines the parameters of a function that interpolates
 !  the four-dimensional gridded data
 !  $$ [x(i),y(j),z(k),q(l),\mathrm{fcn}(i,j,k,l)] ~\mathrm{for}~
-!     i=1,..,n_x ~\mathrm{and}~ j=1,..,n_y, ~\mathrm{and}~ k=1,..,n_z,
-!     ~\mathrm{and}~ l=1,..,n_q $$
+!     i=1_ip,..,n_x ~\mathrm{and}~ j=1_ip,..,n_y, ~\mathrm{and}~ k=1_ip,..,n_z,
+!     ~\mathrm{and}~ l=1_ip,..,n_q $$
 !  The interpolating function and its derivatives may
 !  subsequently be evaluated by the function [[db4val]].
 !
@@ -879,20 +880,20 @@
 
     implicit none
 
-    integer,intent(in)                          :: nx    !! number of \(x\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                          :: ny    !! number of \(y\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                          :: nz    !! number of \(z\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                          :: nq    !! number of \(q\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                          :: kx    !! the order of spline pieces in \(x\)
+    integer(ip),intent(in)                      :: nx    !! number of \(x\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                      :: ny    !! number of \(y\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                      :: nz    !! number of \(z\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                      :: nq    !! number of \(q\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                      :: kx    !! the order of spline pieces in \(x\)
                                                          !! ( \( 2 \le k_x < n_x \) ).
                                                          !! (order = polynomial degree + 1)
-    integer,intent(in)                          :: ky    !! the order of spline pieces in \(y\)
+    integer(ip),intent(in)                      :: ky    !! the order of spline pieces in \(y\)
                                                          !! ( \( 2 \le k_y < n_y \) ).
                                                          !! (order = polynomial degree + 1)
-    integer,intent(in)                          :: kz    !! the order of spline pieces in \(z\)
+    integer(ip),intent(in)                      :: kz    !! the order of spline pieces in \(z\)
                                                          !! ( \( 2 \le k_z < n_z \) ).
                                                          !! (order = polynomial degree + 1)
-    integer,intent(in)                          :: kq    !! the order of spline pieces in \(q\)
+    integer(ip),intent(in)                      :: kq    !! the order of spline pieces in \(q\)
                                                          !! ( \( 2 \le k_q < n_q \) ).
                                                          !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)            :: x     !! `(nx)` array of \(x\) abcissae. must be strictly increasing.
@@ -902,7 +903,7 @@
     real(wp),dimension(:,:,:,:),intent(in)      :: fcn   !! `(nx,ny,nz,nq)` matrix of function values to interpolate.
                                                          !! `fcn(i,j,k,q)` should contain the function value at the
                                                          !!  point (`x(i)`,`y(j)`,`z(k)`,`q(l)`)
-    integer,intent(in)                          :: iknot !! knot sequence flag:
+    integer(ip),intent(in)                      :: iknot !! knot sequence flag:
                                                          !!
                                                          !! * 0 = knot sequence chosen by [[db4ink]].
                                                          !! * 1 = knot sequence chosen by user.
@@ -936,7 +937,7 @@
                                                          !! Must be non-decreasing.
     real(wp),dimension(:,:,:,:),intent(out)     :: bcoef !! `(nx,ny,nz,nq)` matrix of coefficients of the b-spline
                                                          !! interpolant.
-    integer,intent(out)                         :: iflag !! *  0 = successful execution.
+    integer(ip),intent(out)                     :: iflag !! *  0 = successful execution.
                                                          !! *  2 = `iknot` out of range.
                                                          !! *  3 = `nx` out of range.
                                                          !! *  4 = `kx` out of range.
@@ -973,7 +974,8 @@
 
     logical :: status_ok
     real(wp),dimension(:),allocatable :: temp !! work array of dimension `nx*ny*nz*nq`
-    real(wp),dimension(:),allocatable :: work !! work array of dimension `max(2*kx*(nx+1),2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1))`
+    real(wp),dimension(:),allocatable :: work !! work array of dimension `max(2_ip*kx*(nx+1_ip),
+                                              !! 2_ip*ky*(ny+1_ip),2_ip*kz*(nz+1_ip),2_ip*kq*(nq+1_ip))`
 
     ! check validity of input
 
@@ -990,7 +992,7 @@
     if (status_ok) then
 
         ! choose knots
-        if (iknot == 0) then
+        if (iknot == 0_ip) then
             call dbknot(x,nx,kx,tx)
             call dbknot(y,ny,ky,ty)
             call dbknot(z,nz,kz,tz)
@@ -998,13 +1000,13 @@
         end if
 
         allocate(temp(nx*ny*nz*nq))
-        allocate(work(max(2*kx*(nx+1),2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1))))
+        allocate(work(max(2_ip*kx*(nx+1_ip),2_ip*ky*(ny+1_ip),2_ip*kz*(nz+1_ip),2_ip*kq*(nq+1_ip))))
 
         ! construct b-spline coefficients
                       call dbtpcf(x,nx,fcn,  nx,ny*nz*nq,tx,kx,temp, work,iflag)
-        if (iflag==0) call dbtpcf(y,ny,temp, ny,nx*nz*nq,ty,ky,bcoef,work,iflag)
-        if (iflag==0) call dbtpcf(z,nz,bcoef,nz,nx*ny*nq,tz,kz,temp, work,iflag)
-        if (iflag==0) call dbtpcf(q,nq,temp, nq,nx*ny*nz,tq,kq,bcoef,work,iflag)
+        if (iflag==0_ip) call dbtpcf(y,ny,temp, ny,nx*nz*nq,ty,ky,bcoef,work,iflag)
+        if (iflag==0_ip) call dbtpcf(z,nz,bcoef,nz,nx*ny*nq,tz,kz,temp, work,iflag)
+        if (iflag==0_ip) call dbtpcf(q,nq,temp, nq,nx*ny*nz,tq,kq,bcoef,work,iflag)
 
         deallocate(temp)
         deallocate(work)
@@ -1030,35 +1032,35 @@
 !  * Jacob Williams, 2/24/2015 : Created this routine.
 
     pure subroutine db4val(xval,yval,zval,qval,&
-                                idx,idy,idz,idq,&
-                                tx,ty,tz,tq,&
-                                nx,ny,nz,nq,&
-                                kx,ky,kz,kq,&
-                                bcoef,f,iflag,&
-                                inbvx,inbvy,inbvz,inbvq,&
-                                iloy,iloz,iloq,w3,w2,w1,w0,extrap)
+                           idx,idy,idz,idq,&
+                           tx,ty,tz,tq,&
+                           nx,ny,nz,nq,&
+                           kx,ky,kz,kq,&
+                           bcoef,f,iflag,&
+                           inbvx,inbvy,inbvz,inbvq,&
+                           iloy,iloz,iloq,w3,w2,w1,w0,extrap)
 
     implicit none
 
-    integer,intent(in)                         :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                         :: idy      !! \(y\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                         :: idz      !! \(z\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                         :: idq      !! \(q\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                         :: nx       !! the number of interpolation points in \(x\).
+    integer(ip),intent(in)                     :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                     :: idy      !! \(y\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                     :: idz      !! \(z\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                     :: idq      !! \(q\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                     :: nx       !! the number of interpolation points in \(x\).
                                                            !! (same as in last call to [[db4ink]])
-    integer,intent(in)                         :: ny       !! the number of interpolation points in \(y\).
+    integer(ip),intent(in)                     :: ny       !! the number of interpolation points in \(y\).
                                                            !! (same as in last call to [[db4ink]])
-    integer,intent(in)                         :: nz       !! the number of interpolation points in \(z\).
+    integer(ip),intent(in)                     :: nz       !! the number of interpolation points in \(z\).
                                                            !! (same as in last call to [[db4ink]])
-    integer,intent(in)                         :: nq       !! the number of interpolation points in \(q\).
+    integer(ip),intent(in)                     :: nq       !! the number of interpolation points in \(q\).
                                                            !! (same as in last call to [[db4ink]])
-    integer,intent(in)                         :: kx       !! order of polynomial pieces in \(x\).
+    integer(ip),intent(in)                     :: kx       !! order of polynomial pieces in \(x\).
                                                            !! (same as in last call to [[db4ink]])
-    integer,intent(in)                         :: ky       !! order of polynomial pieces in \(y\).
+    integer(ip),intent(in)                     :: ky       !! order of polynomial pieces in \(y\).
                                                            !! (same as in last call to [[db4ink]])
-    integer,intent(in)                         :: kz       !! order of polynomial pieces in \(z\).
+    integer(ip),intent(in)                     :: kz       !! order of polynomial pieces in \(z\).
                                                            !! (same as in last call to [[db4ink]])
-    integer,intent(in)                         :: kq       !! order of polynomial pieces in \(q\).
+    integer(ip),intent(in)                     :: kq       !! order of polynomial pieces in \(q\).
                                                            !! (same as in last call to [[db4ink]])
     real(wp),intent(in)                        :: xval     !! \(x\) coordinate of evaluation point.
     real(wp),intent(in)                        :: yval     !! \(y\) coordinate of evaluation point.
@@ -1078,94 +1080,94 @@
                                                            !! [[db4ink]])
     real(wp),dimension(nx,ny,nz,nq),intent(in) :: bcoef    !! the b-spline coefficients computed by [[db4ink]].
     real(wp),intent(out)                       :: f        !! interpolated value
-    integer,intent(out)                        :: iflag    !! status flag:
+    integer(ip),intent(out)                    :: iflag    !! status flag:
                                                            !!
                                                            !! * \( = 0 \)   : no errors
                                                            !! * \( \ne 0 \) : error
-    integer,intent(inout)                      :: inbvx    !! initialization parameter which must be set
+    integer(ip),intent(inout)                  :: inbvx    !! initialization parameter which must be set
                                                            !! to 1 the first time this routine is called,
                                                            !! and must not be changed by the user.
-    integer,intent(inout)                      :: inbvy    !! initialization parameter which must be set
+    integer(ip),intent(inout)                  :: inbvy    !! initialization parameter which must be set
                                                            !! to 1 the first time this routine is called,
                                                            !! and must not be changed by the user.
-    integer,intent(inout)                      :: inbvz    !! initialization parameter which must be set
+    integer(ip),intent(inout)                  :: inbvz    !! initialization parameter which must be set
                                                            !! to 1 the first time this routine is called,
                                                            !! and must not be changed by the user.
-    integer,intent(inout)                      :: inbvq    !! initialization parameter which must be set
+    integer(ip),intent(inout)                  :: inbvq    !! initialization parameter which must be set
                                                            !! to 1 the first time this routine is called,
                                                            !! and must not be changed by the user.
-    integer,intent(inout)                      :: iloy     !! initialization parameter which must be set
+    integer(ip),intent(inout)                  :: iloy     !! initialization parameter which must be set
                                                            !! to 1 the first time this routine is called,
                                                            !! and must not be changed by the user.
-    integer,intent(inout)                      :: iloz     !! initialization parameter which must be set
+    integer(ip),intent(inout)                  :: iloz     !! initialization parameter which must be set
                                                            !! to 1 the first time this routine is called,
                                                            !! and must not be changed by the user.
-    integer,intent(inout)                      :: iloq     !! initialization parameter which must be set
+    integer(ip),intent(inout)                  :: iloq     !! initialization parameter which must be set
                                                            !! to 1 the first time this routine is called,
                                                            !! and must not be changed by the user.
     real(wp),dimension(ky,kz,kq),intent(inout)           :: w3 !! work array
     real(wp),dimension(kz,kq),intent(inout)              :: w2 !! work array
     real(wp),dimension(kq),intent(inout)                 :: w1 !! work array
-    real(wp),dimension(3*max(kx,ky,kz,kq)),intent(inout) :: w0 !! work array
+    real(wp),dimension(3_ip*max(kx,ky,kz,kq)),intent(inout) :: w0 !! work array
     logical,intent(in),optional                :: extrap   !! if extrapolation is allowed
                                                            !! (if not present, default is False)
 
-    integer :: lefty, leftz, leftq, &
+    integer(ip) :: lefty, leftz, leftq, &
                kcoly, kcolz, kcolq, j, k, q
 
     f = 0.0_wp
 
-    iflag = check_value(xval,tx,1,extrap); if (iflag/=0) return
-    iflag = check_value(yval,ty,2,extrap); if (iflag/=0) return
-    iflag = check_value(zval,tz,3,extrap); if (iflag/=0) return
-    iflag = check_value(qval,tq,4,extrap); if (iflag/=0) return
+    iflag = check_value(xval,tx,1_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(yval,ty,2_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(zval,tz,3_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(qval,tq,4_ip,extrap); if (iflag/=0_ip) return
 
-    call dintrv(ty,ny+ky,yval,iloy,lefty,iflag,extrap); if (iflag/=0) return
-    call dintrv(tz,nz+kz,zval,iloz,leftz,iflag,extrap); if (iflag/=0) return
-    call dintrv(tq,nq+kq,qval,iloq,leftq,iflag,extrap); if (iflag/=0) return
+    call dintrv(ty,ny+ky,yval,iloy,lefty,iflag,extrap); if (iflag/=0_ip) return
+    call dintrv(tz,nz+kz,zval,iloz,leftz,iflag,extrap); if (iflag/=0_ip) return
+    call dintrv(tq,nq+kq,qval,iloq,leftq,iflag,extrap); if (iflag/=0_ip) return
 
-    iflag = 0
+    iflag = 0_ip
 
     ! x -> y, z, q
     kcolq = leftq - kq
-    do q=1,kq
-        kcolq = kcolq + 1
+    do q=1_ip,kq
+        kcolq = kcolq + 1_ip
         kcolz = leftz - kz
-        do k=1,kz
-            kcolz = kcolz + 1
+        do k=1_ip,kz
+            kcolz = kcolz + 1_ip
             kcoly = lefty - ky
-            do j=1,ky
-                kcoly = kcoly + 1
+            do j=1_ip,ky
+                kcoly = kcoly + 1_ip
                 call dbvalu(tx,bcoef(:,kcoly,kcolz,kcolq),&
                                      nx,kx,idx,xval,inbvx,w0,iflag,&
                                      w3(j,k,q),extrap)
-                if (iflag/=0) return
+                if (iflag/=0_ip) return
             end do
         end do
     end do
 
     ! y -> z, q
-    kcoly = lefty - ky + 1
-    do q=1,kq
-        do k=1,kz
+    kcoly = lefty - ky + 1_ip
+    do q=1_ip,kq
+        do k=1_ip,kz
             call dbvalu(ty(kcoly:),w3(:,k,q),&
                         ky,ky,idy,yval,inbvy,w0,iflag,&
                         w2(k,q),extrap)
-            if (iflag/=0) return
+            if (iflag/=0_ip) return
         end do
     end do
 
     ! z -> q
-    kcolz = leftz - kz + 1
-    do q=1,kq
+    kcolz = leftz - kz + 1_ip
+    do q=1_ip,kq
         call dbvalu(tz(kcolz:),w2(:,q),&
                     kz,kz,idz,zval,inbvz,w0,iflag,&
                     w1(q),extrap)
-        if (iflag/=0) return
+        if (iflag/=0_ip) return
     end do
 
     ! q
-    kcolq = leftq - kq + 1
+    kcolq = leftq - kq + 1_ip
     call dbvalu(tq(kcolq:),w1,kq,kq,idq,qval,inbvq,w0,iflag,f,extrap)
 
     end subroutine db4val
@@ -1192,32 +1194,32 @@
 !  * Jacob Williams, 2/24/2015 : Created this routine.
 
     pure subroutine db5ink(x,nx,y,ny,z,nz,q,nq,r,nr,&
-                        fcn,&
-                        kx,ky,kz,kq,kr,&
-                        iknot,&
-                        tx,ty,tz,tq,tr,&
-                        bcoef,iflag)
+                           fcn,&
+                           kx,ky,kz,kq,kr,&
+                           iknot,&
+                           tx,ty,tz,tq,tr,&
+                           bcoef,iflag)
 
     implicit none
 
-    integer,intent(in)                             :: nx    !! number of \(x\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                             :: ny    !! number of \(y\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                             :: nz    !! number of \(z\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                             :: nq    !! number of \(q\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                             :: nr    !! number of \(r\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                             :: kx    !! the order of spline pieces in \(x\)
+    integer(ip),intent(in)                         :: nx    !! number of \(x\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                         :: ny    !! number of \(y\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                         :: nz    !! number of \(z\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                         :: nq    !! number of \(q\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                         :: nr    !! number of \(r\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                         :: kx    !! the order of spline pieces in \(x\)
                                                             !! ( \( 2 \le k_x < n_x \) ).
                                                             !! (order = polynomial degree + 1)
-    integer,intent(in)                             :: ky    !! the order of spline pieces in \(y\)
+    integer(ip),intent(in)                         :: ky    !! the order of spline pieces in \(y\)
                                                             !! ( \( 2 \le k_y < n_y \) ).
                                                             !! (order = polynomial degree + 1)
-    integer,intent(in)                             :: kz    !! the order of spline pieces in \(z\)
+    integer(ip),intent(in)                         :: kz    !! the order of spline pieces in \(z\)
                                                             !! ( \( 2 \le k_z < n_z \) ).
                                                             !! (order = polynomial degree + 1)
-    integer,intent(in)                             :: kq    !! the order of spline pieces in \(q\)
+    integer(ip),intent(in)                         :: kq    !! the order of spline pieces in \(q\)
                                                             !! ( \( 2 \le k_q < n_q \) ).
                                                             !! (order = polynomial degree + 1)
-    integer,intent(in)                             :: kr    !! the order of spline pieces in \(r\)
+    integer(ip),intent(in)                         :: kr    !! the order of spline pieces in \(r\)
                                                             !! ( \( 2 \le k_r < n_r \) ).
                                                             !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)               :: x     !! `(nx)` array of \(x\) abcissae. must be strictly increasing.
@@ -1228,7 +1230,7 @@
     real(wp),dimension(:,:,:,:,:),intent(in)       :: fcn   !! `(nx,ny,nz,nq,nr)` matrix of function values to interpolate.
                                                             !! `fcn(i,j,k,q,r)` should contain the function value at the
                                                             !! point (`x(i)`,`y(j)`,`z(k)`,`q(l)`,`r(m)`)
-    integer,intent(in)                             :: iknot !! knot sequence flag:
+    integer(ip),intent(in)                         :: iknot !! knot sequence flag:
                                                             !!
                                                             !! * 0 = knot sequence chosen by [[db5ink]].
                                                             !! * 1 = knot sequence chosen by user.
@@ -1269,7 +1271,7 @@
                                                             !! Must be non-decreasing.
     real(wp),dimension(:,:,:,:,:),intent(out)      :: bcoef !! `(nx,ny,nz,nq,nr)` matrix of coefficients of the b-spline
                                                             !! interpolant.
-    integer,intent(out)                            :: iflag !! *  0 = successful execution.
+    integer(ip),intent(out)                        :: iflag !! *  0 = successful execution.
                                                             !! *  2 = `iknot` out of range.
                                                             !! *  3 = `nx` out of range.
                                                             !! *  4 = `kx` out of range.
@@ -1315,8 +1317,8 @@
     logical :: status_ok
     real(wp),dimension(:),allocatable :: temp !! work array of length `nx*ny*nz*nq*nr`
     real(wp),dimension(:),allocatable :: work !! work array of length `max(2*kx*(nx+1),
-                                              !! 2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1),2*kr*(nr+1))`
-    integer :: i, j, k, l, m, ii !! counter
+                                              !! 2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1),2_ip*kr*(nr+1))`
+    integer(ip) :: i, j, k, l, m, ii !! counter
 
     !  check validity of input
     call check_inputs(  iknot,&
@@ -1332,7 +1334,7 @@
     if (status_ok) then
 
         !  choose knots
-        if (iknot == 0) then
+        if (iknot == 0_ip) then
             call dbknot(x,nx,kx,tx)
             call dbknot(y,ny,ky,ty)
             call dbknot(z,nz,kz,tz)
@@ -1341,19 +1343,19 @@
         end if
 
         allocate(temp(nx*ny*nz*nq*nr))
-        allocate(work(max(2*kx*(nx+1),2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1),2*kr*(nr+1))))
+        allocate(work(max(2_ip*kx*(nx+1_ip),2_ip*ky*(ny+1_ip),2_ip*kz*(nz+1_ip),2_ip*kq*(nq+1_ip),2_ip*kr*(nr+1_ip))))
 
         ! copy fcn to work in packed for dbtpcf
         !temp(1:nx*ny*nz*nq*nr) = reshape( fcn, [nx*ny*nz*nq*nr] )
         ! replaced with loops to avoid stack
         ! overflow for large data set:
-        ii = 0
-        do m = 1, nr
-            do l = 1, nq
-                do k = 1, nz
-                    do j = 1, ny
-                        do i = 1, nx
-                            ii = ii + 1
+        ii = 0_ip
+        do m = 1_ip, nr
+            do l = 1_ip, nq
+                do k = 1_ip, nz
+                    do j = 1_ip, ny
+                        do i = 1_ip, nx
+                            ii = ii + 1_ip
                             temp(ii) = fcn(i,j,k,l,m)
                         end do
                     end do
@@ -1363,10 +1365,10 @@
 
         !  construct b-spline coefficients
                       call dbtpcf(x,nx,temp,  nx,ny*nz*nq*nr,tx,kx,bcoef,work,iflag)
-        if (iflag==0) call dbtpcf(y,ny,bcoef, ny,nx*nz*nq*nr,ty,ky,temp, work,iflag)
-        if (iflag==0) call dbtpcf(z,nz,temp,  nz,nx*ny*nq*nr,tz,kz,bcoef,work,iflag)
-        if (iflag==0) call dbtpcf(q,nq,bcoef, nq,nx*ny*nz*nr,tq,kq,temp, work,iflag)
-        if (iflag==0) call dbtpcf(r,nr,temp,  nr,nx*ny*nz*nq,tr,kr,bcoef,work,iflag)
+        if (iflag==0_ip) call dbtpcf(y,ny,bcoef, ny,nx*nz*nq*nr,ty,ky,temp, work,iflag)
+        if (iflag==0_ip) call dbtpcf(z,nz,temp,  nz,nx*ny*nq*nr,tz,kz,bcoef,work,iflag)
+        if (iflag==0_ip) call dbtpcf(q,nq,bcoef, nq,nx*ny*nz*nr,tq,kq,temp, work,iflag)
+        if (iflag==0_ip) call dbtpcf(r,nr,temp,  nr,nx*ny*nz*nq,tr,kr,bcoef,work,iflag)
 
         deallocate(temp)
         deallocate(work)
@@ -1392,41 +1394,41 @@
 !  * Jacob Williams, 2/24/2015 : Created this routine.
 
     pure subroutine db5val(xval,yval,zval,qval,rval,&
-                                idx,idy,idz,idq,idr,&
-                                tx,ty,tz,tq,tr,&
-                                nx,ny,nz,nq,nr,&
-                                kx,ky,kz,kq,kr,&
-                                bcoef,f,iflag,&
-                                inbvx,inbvy,inbvz,inbvq,inbvr,&
-                                iloy,iloz,iloq,ilor,&
-                                w4,w3,w2,w1,w0,extrap)
+                           idx,idy,idz,idq,idr,&
+                           tx,ty,tz,tq,tr,&
+                           nx,ny,nz,nq,nr,&
+                           kx,ky,kz,kq,kr,&
+                           bcoef,f,iflag,&
+                           inbvx,inbvy,inbvz,inbvq,inbvr,&
+                           iloy,iloz,iloq,ilor,&
+                           w4,w3,w2,w1,w0,extrap)
 
     implicit none
 
-    integer,intent(in)                            :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                            :: idy      !! \(y\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                            :: idz      !! \(z\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                            :: idq      !! \(q\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                            :: idr      !! \(r\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                            :: nx       !! the number of interpolation points in \(x\).
+    integer(ip),intent(in)                        :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                        :: idy      !! \(y\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                        :: idz      !! \(z\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                        :: idq      !! \(q\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                        :: idr      !! \(r\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                        :: nx       !! the number of interpolation points in \(x\).
                                                               !! (same as in last call to [[db5ink]])
-    integer,intent(in)                            :: ny       !! the number of interpolation points in \(y\).
+    integer(ip),intent(in)                        :: ny       !! the number of interpolation points in \(y\).
                                                               !! (same as in last call to [[db5ink]])
-    integer,intent(in)                            :: nz       !! the number of interpolation points in \(z\).
+    integer(ip),intent(in)                        :: nz       !! the number of interpolation points in \(z\).
                                                               !! (same as in last call to [[db5ink]])
-    integer,intent(in)                            :: nq       !! the number of interpolation points in \(q\).
+    integer(ip),intent(in)                        :: nq       !! the number of interpolation points in \(q\).
                                                               !! (same as in last call to [[db5ink]])
-    integer,intent(in)                            :: nr       !! the number of interpolation points in \(r\).
+    integer(ip),intent(in)                        :: nr       !! the number of interpolation points in \(r\).
                                                               !! (same as in last call to [[db5ink]])
-    integer,intent(in)                            :: kx       !! order of polynomial pieces in \(x\).
+    integer(ip),intent(in)                        :: kx       !! order of polynomial pieces in \(x\).
                                                               !! (same as in last call to [[db5ink]])
-    integer,intent(in)                            :: ky       !! order of polynomial pieces in \(y\).
+    integer(ip),intent(in)                        :: ky       !! order of polynomial pieces in \(y\).
                                                               !! (same as in last call to [[db5ink]])
-    integer,intent(in)                            :: kz       !! order of polynomial pieces in \(z\).
+    integer(ip),intent(in)                        :: kz       !! order of polynomial pieces in \(z\).
                                                               !! (same as in last call to [[db5ink]])
-    integer,intent(in)                            :: kq       !! order of polynomial pieces in \(q\).
+    integer(ip),intent(in)                        :: kq       !! order of polynomial pieces in \(q\).
                                                               !! (same as in last call to [[db5ink]])
-    integer,intent(in)                            :: kr       !! order of polynomial pieces in \(r\).
+    integer(ip),intent(in)                        :: kr       !! order of polynomial pieces in \(r\).
                                                               !! (same as in last call to [[db5ink]])
     real(wp),intent(in)                           :: xval     !! \(x\) coordinate of evaluation point.
     real(wp),intent(in)                           :: yval     !! \(y\) coordinate of evaluation point.
@@ -1450,117 +1452,117 @@
                                                               !! (same as in last call to [[db5ink]])
     real(wp),dimension(nx,ny,nz,nq,nr),intent(in) :: bcoef    !! the b-spline coefficients computed by [[db5ink]].
     real(wp),intent(out)                          :: f        !! interpolated value
-    integer,intent(out)                           :: iflag    !! status flag:
+    integer(ip),intent(out)                       :: iflag    !! status flag:
                                                               !!
                                                               !! * \( = 0 \)   : no errors
                                                               !! * \( \ne 0 \) : error
-    integer,intent(inout)                         :: inbvx    !! initialization parameter which must be set
+    integer(ip),intent(inout)                     :: inbvx    !! initialization parameter which must be set
                                                               !! to 1 the first time this routine is called,
                                                               !! and must not be changed by the user.
-    integer,intent(inout)                         :: inbvy    !! initialization parameter which must be set
+    integer(ip),intent(inout)                     :: inbvy    !! initialization parameter which must be set
                                                               !! to 1 the first time this routine is called,
                                                               !! and must not be changed by the user.
-    integer,intent(inout)                         :: inbvz    !! initialization parameter which must be set
+    integer(ip),intent(inout)                     :: inbvz    !! initialization parameter which must be set
                                                               !! to 1 the first time this routine is called,
                                                               !! and must not be changed by the user.
-    integer,intent(inout)                         :: inbvq    !! initialization parameter which must be set
+    integer(ip),intent(inout)                     :: inbvq    !! initialization parameter which must be set
                                                               !! to 1 the first time this routine is called,
                                                               !! and must not be changed by the user.
-    integer,intent(inout)                         :: inbvr    !! initialization parameter which must be set
+    integer(ip),intent(inout)                     :: inbvr    !! initialization parameter which must be set
                                                               !! to 1 the first time this routine is called,
                                                               !! and must not be changed by the user.
-    integer,intent(inout)                         :: iloy     !! initialization parameter which must be set
+    integer(ip),intent(inout)                     :: iloy     !! initialization parameter which must be set
                                                               !! to 1 the first time this routine is called,
                                                               !! and must not be changed by the user.
-    integer,intent(inout)                         :: iloz     !! initialization parameter which must be set
+    integer(ip),intent(inout)                     :: iloz     !! initialization parameter which must be set
                                                               !! to 1 the first time this routine is called,
                                                               !! and must not be changed by the user.
-    integer,intent(inout)                         :: iloq     !! initialization parameter which must be set
+    integer(ip),intent(inout)                     :: iloq     !! initialization parameter which must be set
                                                               !! to 1 the first time this routine is called,
                                                               !! and must not be changed by the user.
-    integer,intent(inout)                         :: ilor     !! initialization parameter which must be set
+    integer(ip),intent(inout)                     :: ilor     !! initialization parameter which must be set
                                                               !! to 1 the first time this routine is called,
                                                               !! and must not be changed by the user.
     real(wp),dimension(ky,kz,kq,kr),intent(inout)           :: w4  !! work array
     real(wp),dimension(kz,kq,kr),intent(inout)              :: w3  !! work array
     real(wp),dimension(kq,kr),intent(inout)                 :: w2  !! work array
     real(wp),dimension(kr),intent(inout)                    :: w1  !! work array
-    real(wp),dimension(3*max(kx,ky,kz,kq,kr)),intent(inout) :: w0  !! work array
+    real(wp),dimension(3_ip*max(kx,ky,kz,kq,kr)),intent(inout) :: w0  !! work array
     logical,intent(in),optional                   :: extrap   !! if extrapolation is allowed
                                                               !! (if not present, default is False)
 
-    integer :: lefty, leftz, leftq, leftr, &
+    integer(ip) :: lefty, leftz, leftq, leftr, &
                kcoly, kcolz, kcolq, kcolr, j, k, q, r
 
     f = 0.0_wp
 
-    iflag = check_value(xval,tx,1,extrap); if (iflag/=0) return
-    iflag = check_value(yval,ty,2,extrap); if (iflag/=0) return
-    iflag = check_value(zval,tz,3,extrap); if (iflag/=0) return
-    iflag = check_value(qval,tq,4,extrap); if (iflag/=0) return
-    iflag = check_value(rval,tr,5,extrap); if (iflag/=0) return
+    iflag = check_value(xval,tx,1_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(yval,ty,2_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(zval,tz,3_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(qval,tq,4_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(rval,tr,5_ip,extrap); if (iflag/=0_ip) return
 
-    call dintrv(ty,ny+ky,yval,iloy,lefty,iflag,extrap); if (iflag/=0) return
-    call dintrv(tz,nz+kz,zval,iloz,leftz,iflag,extrap); if (iflag/=0) return
-    call dintrv(tq,nq+kq,qval,iloq,leftq,iflag,extrap); if (iflag/=0) return
-    call dintrv(tr,nr+kr,rval,ilor,leftr,iflag,extrap); if (iflag/=0) return
+    call dintrv(ty,ny+ky,yval,iloy,lefty,iflag,extrap); if (iflag/=0_ip) return
+    call dintrv(tz,nz+kz,zval,iloz,leftz,iflag,extrap); if (iflag/=0_ip) return
+    call dintrv(tq,nq+kq,qval,iloq,leftq,iflag,extrap); if (iflag/=0_ip) return
+    call dintrv(tr,nr+kr,rval,ilor,leftr,iflag,extrap); if (iflag/=0_ip) return
 
-    iflag = 0
+    iflag = 0_ip
 
     ! x -> y, z, q, r
     kcolr = leftr - kr
-    do r=1,kr
-        kcolr = kcolr + 1
+    do r=1_ip,kr
+        kcolr = kcolr + 1_ip
         kcolq = leftq - kq
-        do q=1,kq
-            kcolq = kcolq + 1
+        do q=1_ip,kq
+            kcolq = kcolq + 1_ip
             kcolz = leftz - kz
-            do k=1,kz
-                kcolz = kcolz + 1
+            do k=1_ip,kz
+                kcolz = kcolz + 1_ip
                 kcoly = lefty - ky
-                do j=1,ky
-                    kcoly = kcoly + 1
+                do j=1_ip,ky
+                    kcoly = kcoly + 1_ip
                     call dbvalu(tx,bcoef(:,kcoly,kcolz,kcolq,kcolr),&
                                 nx,kx,idx,xval,inbvx,w0,iflag,w4(j,k,q,r),&
                                 extrap)
-                    if (iflag/=0) return
+                    if (iflag/=0_ip) return
                 end do
             end do
         end do
     end do
 
     ! y -> z, q, r
-    kcoly = lefty - ky + 1
-    do r=1,kr
-        do q=1,kq
-            do k=1,kz
+    kcoly = lefty - ky + 1_ip
+    do r=1_ip,kr
+        do q=1_ip,kq
+            do k=1_ip,kz
                 call dbvalu(ty(kcoly:),w4(:,k,q,r),ky,ky,idy,yval,inbvy,&
                             w0,iflag,w3(k,q,r),extrap)
-                if (iflag/=0) return
+                if (iflag/=0_ip) return
             end do
         end do
     end do
 
     ! z -> q, r
-    kcolz = leftz - kz + 1
-    do r=1,kr
-        do q=1,kq
+    kcolz = leftz - kz + 1_ip
+    do r=1_ip,kr
+        do q=1_ip,kq
             call dbvalu(tz(kcolz:),w3(:,q,r),kz,kz,idz,zval,inbvz,&
                         w0,iflag,w2(q,r),extrap)
-            if (iflag/=0) return
+            if (iflag/=0_ip) return
         end do
     end do
 
     ! q -> r
-    kcolq = leftq - kq + 1
-    do r=1,kr
+    kcolq = leftq - kq + 1_ip
+    do r=1_ip,kr
         call dbvalu(tq(kcolq:),w2(:,r),kq,kq,idq,qval,inbvq,&
                     w0,iflag,w1(r),extrap)
-        if (iflag/=0) return
+        if (iflag/=0_ip) return
     end do
 
     ! r
-    kcolr = leftr - kr + 1
+    kcolr = leftr - kr + 1_ip
     call dbvalu(tr(kcolr:),w1,kr,kr,idr,rval,inbvr,w0,iflag,f,extrap)
 
     end subroutine db5val
@@ -1586,36 +1588,36 @@
 !  * Jacob Williams, 2/24/2015 : Created this routine.
 
     pure subroutine db6ink(x,nx,y,ny,z,nz,q,nq,r,nr,s,ns,&
-                        fcn,&
-                        kx,ky,kz,kq,kr,ks,&
-                        iknot,&
-                        tx,ty,tz,tq,tr,ts,&
-                        bcoef,iflag)
+                           fcn,&
+                           kx,ky,kz,kq,kr,ks,&
+                           iknot,&
+                           tx,ty,tz,tq,tr,ts,&
+                           bcoef,iflag)
 
     implicit none
 
-    integer,intent(in)                                :: nx    !! number of \(x\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                                :: ny    !! number of \(y\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                                :: nz    !! number of \(z\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                                :: nq    !! number of \(q\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                                :: nr    !! number of \(r\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                                :: ns    !! number of \(s\) abcissae ( \( \ge 3 \) )
-    integer,intent(in)                                :: kx    !! the order of spline pieces in \(x\)
+    integer(ip),intent(in)                            :: nx    !! number of \(x\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                            :: ny    !! number of \(y\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                            :: nz    !! number of \(z\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                            :: nq    !! number of \(q\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                            :: nr    !! number of \(r\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                            :: ns    !! number of \(s\) abcissae ( \( \ge 3 \) )
+    integer(ip),intent(in)                            :: kx    !! the order of spline pieces in \(x\)
                                                                !! ( \( 2 \le k_x < n_x \) )
                                                                !! (order = polynomial degree + 1)
-    integer,intent(in)                                :: ky    !! the order of spline pieces in \(y\)
+    integer(ip),intent(in)                            :: ky    !! the order of spline pieces in \(y\)
                                                                !! ( \( 2 \le k_y < n_y \) )
                                                                !! (order = polynomial degree + 1)
-    integer,intent(in)                                :: kz    !! the order of spline pieces in \(z\)
+    integer(ip),intent(in)                            :: kz    !! the order of spline pieces in \(z\)
                                                                !! ( \( 2 \le k_z < n_z \) )
                                                                !! (order = polynomial degree + 1)
-    integer,intent(in)                                :: kq    !! the order of spline pieces in \(q\)
+    integer(ip),intent(in)                            :: kq    !! the order of spline pieces in \(q\)
                                                                !! ( \( 2 \le k_q < n_q \) )
                                                                !! (order = polynomial degree + 1)
-    integer,intent(in)                                :: kr    !! the order of spline pieces in \(r\)
+    integer(ip),intent(in)                            :: kr    !! the order of spline pieces in \(r\)
                                                                !! ( \( 2 \le k_r < n_r \) )
                                                                !! (order = polynomial degree + 1)
-    integer,intent(in)                                :: ks    !! the order of spline pieces in \(s\)
+    integer(ip),intent(in)                            :: ks    !! the order of spline pieces in \(s\)
                                                                !! ( \( 2 \le k_s < n_s \) )
                                                                !! (order = polynomial degree + 1)
     real(wp),dimension(:),intent(in)                  :: x     !! `(nx)` array of \(x\) abcissae.
@@ -1634,7 +1636,7 @@
                                                                !! interpolate. `fcn(i,j,k,q,r,s)` should contain the
                                                                !! function value at the point
                                                                !! (`x(i)`,`y(j)`,`z(k)`,`q(l)`,`r(m)`,`s(n)`)
-    integer,intent(in)                                :: iknot !! knot sequence flag:
+    integer(ip),intent(in)                            :: iknot !! knot sequence flag:
                                                                !!
                                                                !! * 0 = knot sequence chosen by [[db6ink]].
                                                                !! * 1 = knot sequence chosen by user.
@@ -1682,7 +1684,7 @@
                                                                !! Must be non-decreasing.
     real(wp),dimension(:,:,:,:,:,:),intent(out)       :: bcoef !! `(nx,ny,nz,nq,nr,ns)` matrix of coefficients of the
                                                                !! b-spline interpolant.
-    integer,intent(out)                               :: iflag !! *  0 = successful execution.
+    integer(ip),intent(out)                           :: iflag !! *  0 = successful execution.
                                                                !! *  2 = `iknot` out of range.
                                                                !! *  3 = `nx` out of range.
                                                                !! *  4 = `kx` out of range.
@@ -1736,7 +1738,8 @@
     logical :: status_ok
     real(wp),dimension(:),allocatable :: temp !! work array of size `nx*ny*nz*nq*nr*ns`
     real(wp),dimension(:),allocatable :: work !! work array of size `max(2*kx*(nx+1),
-                                              !! 2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1),2*kr*(nr+1),2*ks*(ns+1))`
+                                              !! 2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1),
+                                              !! 2*kr*(nr+1),2*ks*(ns+1))`
 
     ! check validity of input
     call check_inputs(  iknot,&
@@ -1752,7 +1755,7 @@
     if (status_ok) then
 
         ! choose knots
-        if (iknot == 0) then
+        if (iknot == 0_ip) then
             call dbknot(x,nx,kx,tx)
             call dbknot(y,ny,ky,ty)
             call dbknot(z,nz,kz,tz)
@@ -1762,15 +1765,17 @@
         end if
 
         allocate(temp(nx*ny*nz*nq*nr*ns))
-        allocate(work(max(2*kx*(nx+1),2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1),2*kr*(nr+1),2*ks*(ns+1))))
+        allocate(work(max(2_ip*kx*(nx+1_ip),2_ip*ky*(ny+1_ip),&
+                          2_ip*kz*(nz+1_ip),2_ip*kq*(nq+1_ip),&
+                          2_ip*kr*(nr+1_ip),2_ip*ks*(ns+1_ip))))
 
         ! construct b-spline coefficients
-                      call dbtpcf(x,nx,fcn,  nx,ny*nz*nq*nr*ns,tx,kx,temp, work,iflag)
-        if (iflag==0) call dbtpcf(y,ny,temp, ny,nx*nz*nq*nr*ns,ty,ky,bcoef,work,iflag)
-        if (iflag==0) call dbtpcf(z,nz,bcoef,nz,nx*ny*nq*nr*ns,tz,kz,temp, work,iflag)
-        if (iflag==0) call dbtpcf(q,nq,temp, nq,nx*ny*nz*nr*ns,tq,kq,bcoef,work,iflag)
-        if (iflag==0) call dbtpcf(r,nr,bcoef,nr,nx*ny*nz*nq*ns,tr,kr,temp, work,iflag)
-        if (iflag==0) call dbtpcf(s,ns,temp, ns,nx*ny*nz*nq*nr,ts,ks,bcoef,work,iflag)
+                         call dbtpcf(x,nx,fcn,  nx,ny*nz*nq*nr*ns,tx,kx,temp, work,iflag)
+        if (iflag==0_ip) call dbtpcf(y,ny,temp, ny,nx*nz*nq*nr*ns,ty,ky,bcoef,work,iflag)
+        if (iflag==0_ip) call dbtpcf(z,nz,bcoef,nz,nx*ny*nq*nr*ns,tz,kz,temp, work,iflag)
+        if (iflag==0_ip) call dbtpcf(q,nq,temp, nq,nx*ny*nz*nr*ns,tq,kq,bcoef,work,iflag)
+        if (iflag==0_ip) call dbtpcf(r,nr,bcoef,nr,nx*ny*nz*nq*ns,tr,kr,temp, work,iflag)
+        if (iflag==0_ip) call dbtpcf(s,ns,temp, ns,nx*ny*nz*nq*nr,ts,ks,bcoef,work,iflag)
 
         deallocate(temp)
         deallocate(work)
@@ -1796,46 +1801,46 @@
 !  * Jacob Williams, 2/24/2015 : Created this routine.
 
     pure subroutine db6val(xval,yval,zval,qval,rval,sval,&
-                                idx,idy,idz,idq,idr,ids,&
-                                tx,ty,tz,tq,tr,ts,&
-                                nx,ny,nz,nq,nr,ns,&
-                                kx,ky,kz,kq,kr,ks,&
-                                bcoef,f,iflag,&
-                                inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,&
-                                iloy,iloz,iloq,ilor,ilos,&
-                                w5,w4,w3,w2,w1,w0,extrap)
+                           idx,idy,idz,idq,idr,ids,&
+                           tx,ty,tz,tq,tr,ts,&
+                           nx,ny,nz,nq,nr,ns,&
+                           kx,ky,kz,kq,kr,ks,&
+                           bcoef,f,iflag,&
+                           inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,&
+                           iloy,iloz,iloq,ilor,ilos,&
+                           w5,w4,w3,w2,w1,w0,extrap)
 
     implicit none
 
-    integer,intent(in)                               :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                               :: idy      !! \(y\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                               :: idz      !! \(z\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                               :: idq      !! \(q\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                               :: idr      !! \(r\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                               :: ids      !! \(s\) derivative of piecewise polynomial to evaluate.
-    integer,intent(in)                               :: nx       !! the number of interpolation points in \(x\).
+    integer(ip),intent(in)                           :: idx      !! \(x\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                           :: idy      !! \(y\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                           :: idz      !! \(z\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                           :: idq      !! \(q\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                           :: idr      !! \(r\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                           :: ids      !! \(s\) derivative of piecewise polynomial to evaluate.
+    integer(ip),intent(in)                           :: nx       !! the number of interpolation points in \(x\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: ny       !! the number of interpolation points in \(y\).
+    integer(ip),intent(in)                           :: ny       !! the number of interpolation points in \(y\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: nz       !! the number of interpolation points in \(z\).
+    integer(ip),intent(in)                           :: nz       !! the number of interpolation points in \(z\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: nq       !! the number of interpolation points in \(q\).
+    integer(ip),intent(in)                           :: nq       !! the number of interpolation points in \(q\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: nr       !! the number of interpolation points in \(r\).
+    integer(ip),intent(in)                           :: nr       !! the number of interpolation points in \(r\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: ns       !! the number of interpolation points in \(s\).
+    integer(ip),intent(in)                           :: ns       !! the number of interpolation points in \(s\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: kx       !! order of polynomial pieces in \(x\).
+    integer(ip),intent(in)                           :: kx       !! order of polynomial pieces in \(x\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: ky       !! order of polynomial pieces in \(y\).
+    integer(ip),intent(in)                           :: ky       !! order of polynomial pieces in \(y\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: kz       !! order of polynomial pieces in \(z\).
+    integer(ip),intent(in)                           :: kz       !! order of polynomial pieces in \(z\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: kq       !! order of polynomial pieces in \(q\).
+    integer(ip),intent(in)                           :: kq       !! order of polynomial pieces in \(q\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: kr       !! order of polynomial pieces in \(r\).
+    integer(ip),intent(in)                           :: kr       !! order of polynomial pieces in \(r\).
                                                                  !! (same as in last call to [[db6ink]])
-    integer,intent(in)                               :: ks       !! order of polynomial pieces in \(s\).
+    integer(ip),intent(in)                           :: ks       !! order of polynomial pieces in \(s\).
                                                                  !! (same as in last call to [[db6ink]])
     real(wp),intent(in)                              :: xval     !! \(x\) coordinate of evaluation point.
     real(wp),intent(in)                              :: yval     !! \(y\) coordinate of evaluation point.
@@ -1863,93 +1868,93 @@
                                                                  !! (same as in last call to [[db6ink]])
     real(wp),dimension(nx,ny,nz,nq,nr,ns),intent(in) :: bcoef    !! the b-spline coefficients computed by [[db6ink]].
     real(wp),intent(out)                             :: f        !! interpolated value
-    integer,intent(out)                              :: iflag    !! status flag:
+    integer(ip),intent(out)                          :: iflag    !! status flag:
                                                                  !!
                                                                  !! * \( = 0 \)   : no errors
                                                                  !! * \( \ne 0 \) : error
-    integer,intent(inout)                            :: inbvx    !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: inbvx    !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    integer,intent(inout)                            :: inbvy    !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: inbvy    !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    integer,intent(inout)                            :: inbvz    !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: inbvz    !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    integer,intent(inout)                            :: inbvq    !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: inbvq    !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    integer,intent(inout)                            :: inbvr    !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: inbvr    !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    integer,intent(inout)                            :: inbvs    !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: inbvs    !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    integer,intent(inout)                            :: iloy     !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: iloy     !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    integer,intent(inout)                            :: iloz     !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: iloz     !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    integer,intent(inout)                            :: iloq     !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: iloq     !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    integer,intent(inout)                            :: ilor     !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: ilor     !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    integer,intent(inout)                            :: ilos     !! initialization parameter which must be set
+    integer(ip),intent(inout)                        :: ilos     !! initialization parameter which must be set
                                                                  !! to 1 the first time this routine is called,
                                                                  !! and must not be changed by the user.
-    real(wp),dimension(ky,kz,kq,kr,ks),intent(inout)           :: w5 !! work array
-    real(wp),dimension(kz,kq,kr,ks),intent(inout)              :: w4 !! work array
-    real(wp),dimension(kq,kr,ks),intent(inout)                 :: w3 !! work array
-    real(wp),dimension(kr,ks),intent(inout)                    :: w2 !! work array
-    real(wp),dimension(ks),intent(inout)                       :: w1 !! work array
-    real(wp),dimension(3*max(kx,ky,kz,kq,kr,ks)),intent(inout) :: w0 !! work array
+    real(wp),dimension(ky,kz,kq,kr,ks),intent(inout)              :: w5 !! work array
+    real(wp),dimension(kz,kq,kr,ks),intent(inout)                 :: w4 !! work array
+    real(wp),dimension(kq,kr,ks),intent(inout)                    :: w3 !! work array
+    real(wp),dimension(kr,ks),intent(inout)                       :: w2 !! work array
+    real(wp),dimension(ks),intent(inout)                          :: w1 !! work array
+    real(wp),dimension(3_ip*max(kx,ky,kz,kq,kr,ks)),intent(inout) :: w0 !! work array
     logical,intent(in),optional                      :: extrap   !! if extrapolation is allowed
                                                                  !! (if not present, default is False)
 
-    integer :: lefty,leftz,leftq,leftr,lefts,&
-               kcoly,kcolz,kcolq,kcolr,kcols,&
-               j,k,q,r,s
+    integer(ip) :: lefty,leftz,leftq,leftr,lefts,&
+                   kcoly,kcolz,kcolq,kcolr,kcols,&
+                   j,k,q,r,s
 
     f = 0.0_wp
 
-    iflag = check_value(xval,tx,1,extrap); if (iflag/=0) return
-    iflag = check_value(yval,ty,2,extrap); if (iflag/=0) return
-    iflag = check_value(zval,tz,3,extrap); if (iflag/=0) return
-    iflag = check_value(qval,tq,4,extrap); if (iflag/=0) return
-    iflag = check_value(rval,tr,5,extrap); if (iflag/=0) return
-    iflag = check_value(sval,ts,6,extrap); if (iflag/=0) return
+    iflag = check_value(xval,tx,1_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(yval,ty,2_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(zval,tz,3_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(qval,tq,4_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(rval,tr,5_ip,extrap); if (iflag/=0_ip) return
+    iflag = check_value(sval,ts,6_ip,extrap); if (iflag/=0_ip) return
 
-    call dintrv(ty,ny+ky,yval,iloy,lefty,iflag,extrap); if (iflag/=0) return
-    call dintrv(tz,nz+kz,zval,iloz,leftz,iflag,extrap); if (iflag/=0) return
-    call dintrv(tq,nq+kq,qval,iloq,leftq,iflag,extrap); if (iflag/=0) return
-    call dintrv(tr,nr+kr,rval,ilor,leftr,iflag,extrap); if (iflag/=0) return
-    call dintrv(ts,ns+ks,sval,ilos,lefts,iflag,extrap); if (iflag/=0) return
+    call dintrv(ty,ny+ky,yval,iloy,lefty,iflag,extrap); if (iflag/=0_ip) return
+    call dintrv(tz,nz+kz,zval,iloz,leftz,iflag,extrap); if (iflag/=0_ip) return
+    call dintrv(tq,nq+kq,qval,iloq,leftq,iflag,extrap); if (iflag/=0_ip) return
+    call dintrv(tr,nr+kr,rval,ilor,leftr,iflag,extrap); if (iflag/=0_ip) return
+    call dintrv(ts,ns+ks,sval,ilos,lefts,iflag,extrap); if (iflag/=0_ip) return
 
-    iflag = 0
+    iflag = 0_ip
 
     ! x -> y, z, q, r, s
     kcols = lefts - ks
-    do s=1,ks
-        kcols = kcols + 1
+    do s=1_ip,ks
+        kcols = kcols + 1_ip
         kcolr = leftr - kr
-        do r=1,kr
-            kcolr = kcolr + 1
+        do r=1_ip,kr
+            kcolr = kcolr + 1_ip
             kcolq = leftq - kq
-            do q=1,kq
-                kcolq = kcolq + 1
+            do q=1_ip,kq
+                kcolq = kcolq + 1_ip
                 kcolz = leftz - kz
-                do k=1,kz
-                    kcolz = kcolz + 1
+                do k=1_ip,kz
+                    kcolz = kcolz + 1_ip
                     kcoly = lefty - ky
-                    do j=1,ky
-                        kcoly = kcoly + 1
+                    do j=1_ip,ky
+                        kcoly = kcoly + 1_ip
                         call dbvalu(tx,bcoef(:,kcoly,kcolz,kcolq,kcolr,kcols),&
                                              nx,kx,idx,xval,inbvx,w0,iflag,&
                                              w5(j,k,q,r,s),extrap)
-                        if (iflag/=0) return
+                        if (iflag/=0_ip) return
                     end do
                 end do
             end do
@@ -1957,55 +1962,55 @@
     end do
 
     ! y -> z, q, r, s
-    kcoly = lefty - ky + 1
-    do s=1,ks
-        do r=1,kr
-            do q=1,kq
-                do k=1,kz
+    kcoly = lefty - ky + 1_ip
+    do s=1_ip,ks
+        do r=1_ip,kr
+            do q=1_ip,kq
+                do k=1_ip,kz
                     call dbvalu(ty(kcoly:),w5(:,k,q,r,s),&
                                 ky,ky,idy,yval,inbvy,w0,iflag,&
                                 w4(k,q,r,s),extrap)
-                    if (iflag/=0) return
+                    if (iflag/=0_ip) return
                 end do
             end do
         end do
     end do
 
     ! z -> q, r, s
-    kcolz = leftz - kz + 1
-    do s=1,ks
-        do r=1,kr
-            do q=1,kq
+    kcolz = leftz - kz + 1_ip
+    do s=1_ip,ks
+        do r=1_ip,kr
+            do q=1_ip,kq
                 call dbvalu(tz(kcolz:),w4(:,q,r,s),&
                             kz,kz,idz,zval,inbvz,w0,iflag,&
                             w3(q,r,s),extrap)
-                if (iflag/=0) return
+                if (iflag/=0_ip) return
             end do
         end do
     end do
 
     ! q -> r, s
-    kcolq = leftq - kq + 1
-    do s=1,ks
-        do r=1,kr
+    kcolq = leftq - kq + 1_ip
+    do s=1_ip,ks
+        do r=1_ip,kr
             call dbvalu(tq(kcolq:),w3(:,r,s),&
                         kq,kq,idq,qval,inbvq,w0,iflag,&
                         w2(r,s),extrap)
-            if (iflag/=0) return
+            if (iflag/=0_ip) return
         end do
     end do
 
     ! r -> s
-    kcolr = leftr - kr + 1
-    do s=1,ks
+    kcolr = leftr - kr + 1_ip
+    do s=1_ip,ks
         call dbvalu(tr(kcolr:),w2(:,s),&
                     kr,kr,idr,rval,inbvr,w0,iflag,&
                     w1(s),extrap)
-        if (iflag/=0) return
+        if (iflag/=0_ip) return
     end do
 
     ! s
-    kcols = lefts - ks + 1
+    kcols = lefts - ks + 1_ip
     call dbvalu(ts(kcols:),w1,ks,ks,ids,sval,inbvs,w0,iflag,f,extrap)
 
     end subroutine db6val
@@ -2020,12 +2025,12 @@
 
     implicit none
 
-    integer :: iflag  !! returns 0 if value is OK, otherwise returns `600+i`
-    real(wp),intent(in) :: x !! the value to check
-    integer,intent(in) :: i !! 1=x, 2=y, 3=z, 4=q, 5=r, 6=s
-    real(wp),dimension(:),intent(in) :: t  !! the knot vector
-    logical,intent(in),optional :: extrap  !! if extrapolation is allowed
-                                           !! (if not present, default is False)
+    integer(ip)                      :: iflag   !! returns 0 if value is OK, otherwise returns `600+i`
+    real(wp),intent(in)              :: x       !! the value to check
+    integer(ip),intent(in)           :: i       !! 1=x, 2=y, 3=z, 4=q, 5=r, 6=s
+    real(wp),dimension(:),intent(in) :: t       !! the knot vector
+    logical,intent(in),optional      :: extrap  !! if extrapolation is allowed
+                                                !! (if not present, default is False)
 
     logical :: allow_extrapolation  !! if extrapolation is allowed
 
@@ -2037,12 +2042,12 @@
 
     if (allow_extrapolation) then
         ! in this case all values are OK
-        iflag = 0
+        iflag = 0_ip
     else
-        if (x<t(1) .or. x>t(size(t))) then
-            iflag = 600 + i  ! value out of bounds (601, 602, etc.)
+        if (x<t(1_ip) .or. x>t(size(t,kind=ip))) then
+            iflag = 600_ip + i  ! value out of bounds (601, 602, etc.)
         else
-            iflag = 0
+            iflag = 0_ip
         end if
     end if
 
@@ -2077,10 +2082,10 @@
 
     implicit none
 
-    integer,intent(in)                                  :: iknot !! = 0 if the `INK` routine is computing the knots.
-    integer,intent(out)                                 :: iflag
-    integer,intent(in),optional                         :: nx,ny,nz,nq,nr,ns
-    integer,intent(in),optional                         :: kx,ky,kz,kq,kr,ks
+    integer(ip),intent(in)                              :: iknot !! = 0 if the `INK` routine is computing the knots.
+    integer(ip),intent(out)                             :: iflag
+    integer(ip),intent(in),optional                     :: nx,ny,nz,nq,nr,ns
+    integer(ip),intent(in),optional                     :: kx,ky,kz,kq,kr,ks
     real(wp),dimension(:),intent(in),optional           :: x,y,z,q,r,s
     real(wp),dimension(:),intent(in),optional           :: tx,ty,tz,tq,tr,ts
     real(wp),dimension(:),intent(in),optional           :: f1,bcoef1
@@ -2095,80 +2100,80 @@
 
     status_ok = .false.
 
-    if ((iknot < 0) .or. (iknot > 1)) then
+    if ((iknot < 0_ip) .or. (iknot > 1_ip)) then
 
-        iflag = 2 ! iknot is out of range
+        iflag = 2_ip ! iknot is out of range
 
     else
 
-        call check('x',nx,kx,x,tx,[3,  4, 5, 6,706,712],iflag,error); if (error) return
-        call check('y',ny,ky,y,ty,[7,  8, 9,10,707,713],iflag,error); if (error) return
-        call check('z',nz,kz,z,tz,[11,12,13,14,708,714],iflag,error); if (error) return
-        call check('q',nq,kq,q,tq,[15,16,17,18,709,715],iflag,error); if (error) return
-        call check('r',nr,kr,r,tr,[19,20,21,22,710,716],iflag,error); if (error) return
-        call check('s',ns,ks,s,ts,[23,24,25,26,711,717],iflag,error); if (error) return
+        call check('x',nx,kx,x,tx,[3_ip,  4_ip, 5_ip, 6_ip,706_ip,712_ip],iflag,error); if (error) return
+        call check('y',ny,ky,y,ty,[7_ip,  8_ip, 9_ip,10_ip,707_ip,713_ip],iflag,error); if (error) return
+        call check('z',nz,kz,z,tz,[11_ip,12_ip,13_ip,14_ip,708_ip,714_ip],iflag,error); if (error) return
+        call check('q',nq,kq,q,tq,[15_ip,16_ip,17_ip,18_ip,709_ip,715_ip],iflag,error); if (error) return
+        call check('r',nr,kr,r,tr,[19_ip,20_ip,21_ip,22_ip,710_ip,716_ip],iflag,error); if (error) return
+        call check('s',ns,ks,s,ts,[23_ip,24_ip,25_ip,26_ip,711_ip,717_ip],iflag,error); if (error) return
 
         if (present(x) .and. present(f1) .and. present(bcoef1)) then
-            if (size(x)/=size(f1,1))     then; iflag = 700; return; end if
-            if (size(x)/=size(bcoef1,1)) then; iflag = 800; return; end if
+            if (size(x,kind=ip)/=size(f1,1_ip,kind=ip))     then; iflag = 700_ip; return; end if
+            if (size(x,kind=ip)/=size(bcoef1,1_ip,kind=ip)) then; iflag = 800_ip; return; end if
         end if
         if (present(x) .and. present(y) .and. present(f2) .and. present(bcoef2)) then
-            if (size(x)/=size(f2,1))     then; iflag = 700; return; end if
-            if (size(y)/=size(f2,2))     then; iflag = 701; return; end if
-            if (size(x)/=size(bcoef2,1)) then; iflag = 800; return; end if
-            if (size(y)/=size(bcoef2,2)) then; iflag = 801; return; end if
+            if (size(x,kind=ip)/=size(f2,1_ip,kind=ip))     then; iflag = 700_ip; return; end if
+            if (size(y,kind=ip)/=size(f2,2_ip,kind=ip))     then; iflag = 701_ip; return; end if
+            if (size(x,kind=ip)/=size(bcoef2,1_ip,kind=ip)) then; iflag = 800_ip; return; end if
+            if (size(y,kind=ip)/=size(bcoef2,2_ip,kind=ip)) then; iflag = 801_ip; return; end if
         end if
         if (present(x) .and. present(y) .and. present(z) .and. present(f3) .and. &
             present(bcoef3)) then
-            if (size(x)/=size(f3,1))     then; iflag = 700; return; end if
-            if (size(y)/=size(f3,2))     then; iflag = 701; return; end if
-            if (size(z)/=size(f3,3))     then; iflag = 702; return; end if
-            if (size(x)/=size(bcoef3,1)) then; iflag = 800; return; end if
-            if (size(y)/=size(bcoef3,2)) then; iflag = 801; return; end if
-            if (size(z)/=size(bcoef3,3)) then; iflag = 802; return; end if
+            if (size(x,kind=ip)/=size(f3,1_ip,kind=ip))     then; iflag = 700_ip; return; end if
+            if (size(y,kind=ip)/=size(f3,2_ip,kind=ip))     then; iflag = 701_ip; return; end if
+            if (size(z,kind=ip)/=size(f3,3_ip,kind=ip))     then; iflag = 702_ip; return; end if
+            if (size(x,kind=ip)/=size(bcoef3,1_ip,kind=ip)) then; iflag = 800_ip; return; end if
+            if (size(y,kind=ip)/=size(bcoef3,2_ip,kind=ip)) then; iflag = 801_ip; return; end if
+            if (size(z,kind=ip)/=size(bcoef3,3_ip,kind=ip)) then; iflag = 802_ip; return; end if
         end if
         if (present(x) .and. present(y) .and. present(z) .and. present(q) .and. &
             present(f4) .and. present(bcoef4)) then
-            if (size(x)/=size(f4,1))     then; iflag = 700; return; end if
-            if (size(y)/=size(f4,2))     then; iflag = 701; return; end if
-            if (size(z)/=size(f4,3))     then; iflag = 702; return; end if
-            if (size(q)/=size(f4,4))     then; iflag = 703; return; end if
-            if (size(x)/=size(bcoef4,1)) then; iflag = 800; return; end if
-            if (size(y)/=size(bcoef4,2)) then; iflag = 801; return; end if
-            if (size(z)/=size(bcoef4,3)) then; iflag = 802; return; end if
-            if (size(q)/=size(bcoef4,4)) then; iflag = 803; return; end if
+            if (size(x,kind=ip)/=size(f4,1_ip,kind=ip))     then; iflag = 700_ip; return; end if
+            if (size(y,kind=ip)/=size(f4,2_ip,kind=ip))     then; iflag = 701_ip; return; end if
+            if (size(z,kind=ip)/=size(f4,3_ip,kind=ip))     then; iflag = 702_ip; return; end if
+            if (size(q,kind=ip)/=size(f4,4_ip,kind=ip))     then; iflag = 703_ip; return; end if
+            if (size(x,kind=ip)/=size(bcoef4,1_ip,kind=ip)) then; iflag = 800_ip; return; end if
+            if (size(y,kind=ip)/=size(bcoef4,2_ip,kind=ip)) then; iflag = 801_ip; return; end if
+            if (size(z,kind=ip)/=size(bcoef4,3_ip,kind=ip)) then; iflag = 802_ip; return; end if
+            if (size(q,kind=ip)/=size(bcoef4,4_ip,kind=ip)) then; iflag = 803_ip; return; end if
         end if
         if (present(x) .and. present(y) .and. present(z) .and. present(q) .and. &
             present(r) .and. present(f5) .and. present(bcoef5)) then
-            if (size(x)/=size(f5,1))     then; iflag = 700; return; end if
-            if (size(y)/=size(f5,2))     then; iflag = 701; return; end if
-            if (size(z)/=size(f5,3))     then; iflag = 702; return; end if
-            if (size(q)/=size(f5,4))     then; iflag = 703; return; end if
-            if (size(r)/=size(f5,5))     then; iflag = 704; return; end if
-            if (size(x)/=size(bcoef5,1)) then; iflag = 800; return; end if
-            if (size(y)/=size(bcoef5,2)) then; iflag = 801; return; end if
-            if (size(z)/=size(bcoef5,3)) then; iflag = 802; return; end if
-            if (size(q)/=size(bcoef5,4)) then; iflag = 803; return; end if
-            if (size(r)/=size(bcoef5,5)) then; iflag = 804; return; end if
+            if (size(x,kind=ip)/=size(f5,1_ip,kind=ip))     then; iflag = 700_ip; return; end if
+            if (size(y,kind=ip)/=size(f5,2_ip,kind=ip))     then; iflag = 701_ip; return; end if
+            if (size(z,kind=ip)/=size(f5,3_ip,kind=ip))     then; iflag = 702_ip; return; end if
+            if (size(q,kind=ip)/=size(f5,4_ip,kind=ip))     then; iflag = 703_ip; return; end if
+            if (size(r,kind=ip)/=size(f5,5_ip,kind=ip))     then; iflag = 704_ip; return; end if
+            if (size(x,kind=ip)/=size(bcoef5,1_ip,kind=ip)) then; iflag = 800_ip; return; end if
+            if (size(y,kind=ip)/=size(bcoef5,2_ip,kind=ip)) then; iflag = 801_ip; return; end if
+            if (size(z,kind=ip)/=size(bcoef5,3_ip,kind=ip)) then; iflag = 802_ip; return; end if
+            if (size(q,kind=ip)/=size(bcoef5,4_ip,kind=ip)) then; iflag = 803_ip; return; end if
+            if (size(r,kind=ip)/=size(bcoef5,5_ip,kind=ip)) then; iflag = 804_ip; return; end if
         end if
         if (present(x) .and. present(y) .and. present(z) .and. present(q) .and. &
             present(r) .and. present(s) .and. present(f6) .and. present(bcoef6)) then
-            if (size(x)/=size(f6,1))     then; iflag = 700; return; end if
-            if (size(y)/=size(f6,2))     then; iflag = 701; return; end if
-            if (size(z)/=size(f6,3))     then; iflag = 702; return; end if
-            if (size(q)/=size(f6,4))     then; iflag = 703; return; end if
-            if (size(r)/=size(f6,5))     then; iflag = 704; return; end if
-            if (size(s)/=size(f6,6))     then; iflag = 705; return; end if
-            if (size(x)/=size(bcoef6,1)) then; iflag = 800; return; end if
-            if (size(y)/=size(bcoef6,2)) then; iflag = 801; return; end if
-            if (size(z)/=size(bcoef6,3)) then; iflag = 802; return; end if
-            if (size(q)/=size(bcoef6,4)) then; iflag = 803; return; end if
-            if (size(r)/=size(bcoef6,5)) then; iflag = 804; return; end if
-            if (size(s)/=size(bcoef6,6)) then; iflag = 805; return; end if
+            if (size(x,kind=ip)/=size(f6,1_ip,kind=ip))     then; iflag = 700_ip; return; end if
+            if (size(y,kind=ip)/=size(f6,2_ip,kind=ip))     then; iflag = 701_ip; return; end if
+            if (size(z,kind=ip)/=size(f6,3_ip,kind=ip))     then; iflag = 702_ip; return; end if
+            if (size(q,kind=ip)/=size(f6,4_ip,kind=ip))     then; iflag = 703_ip; return; end if
+            if (size(r,kind=ip)/=size(f6,5_ip,kind=ip))     then; iflag = 704_ip; return; end if
+            if (size(s,kind=ip)/=size(f6,6_ip,kind=ip))     then; iflag = 705_ip; return; end if
+            if (size(x,kind=ip)/=size(bcoef6,1_ip,kind=ip)) then; iflag = 800_ip; return; end if
+            if (size(y,kind=ip)/=size(bcoef6,2_ip,kind=ip)) then; iflag = 801_ip; return; end if
+            if (size(z,kind=ip)/=size(bcoef6,3_ip,kind=ip)) then; iflag = 802_ip; return; end if
+            if (size(q,kind=ip)/=size(bcoef6,4_ip,kind=ip)) then; iflag = 803_ip; return; end if
+            if (size(r,kind=ip)/=size(bcoef6,5_ip,kind=ip)) then; iflag = 804_ip; return; end if
+            if (size(s,kind=ip)/=size(bcoef6,6_ip,kind=ip)) then; iflag = 805_ip; return; end if
         end if
 
         status_ok = .true.
-        iflag = 0
+        iflag = 0_ip
 
     end if
 
@@ -2179,23 +2184,23 @@
         implicit none
 
         character(len=1),intent(in)               :: s     !! coordinate string: 'x','y','z','q','r','s'
-        integer,intent(in)              ,optional :: n     !! size of `x`
-        integer,intent(in)              ,optional :: k     !! order
+        integer(ip),intent(in),optional           :: n     !! size of `x`
+        integer(ip),intent(in),optional           :: k     !! order
         real(wp),dimension(:),intent(in),optional :: x     !! abcissae vector
         real(wp),dimension(:),intent(in),optional :: t     !! knot vector `size(n+k)`
-        integer,dimension(:),intent(in)           :: ierrs !! int error codes for `n`,`k`,`x`,`t`,
+        integer(ip),dimension(:),intent(in)       :: ierrs !! int error codes for `n`,`k`,`x`,`t`,
                                                            !! `size(x)`,`size(t)` checks
-        integer,intent(out)                       :: iflag !! status return code
+        integer(ip),intent(out)                   :: iflag !! status return code
         logical,intent(out)                       :: error !! true if there was an error
 
-        integer,dimension(:),allocatable :: itmp !! temp integer array
+        integer(ip),dimension(:),allocatable :: itmp !! temp integer array
 
         if (present(n) .and. present(k) .and. present(x) .and. present(t)) then
-            itmp = [ierrs(1),ierrs(5)]
-            call check_n('n'//s,n,x,itmp,iflag,error); if (error) return
+            itmp = [ierrs(1_ip),ierrs(5)]
+            call check_n('n'//s,n,x,itmp,iflag,error);     if (error) return
             call check_k('k'//s,k,n,ierrs(2),iflag,error); if (error) return
-            call check_x(s,n,x,ierrs(3),iflag,error); if (error) return
-            if (iknot /= 0) then
+            call check_x(s,n,x,ierrs(3),iflag,error);      if (error) return
+            if (iknot /= 0_ip) then
                 itmp = [ierrs(4),ierrs(6)]
                 call check_t('t'//s,n,k,t,itmp,iflag,error); if (error) return
             end if
@@ -2207,15 +2212,15 @@
 
         implicit none
 
-        character(len=*),intent(in)     :: s
-        integer,intent(in)              :: n
-        real(wp),dimension(:),intent(in):: x     !! abcissae vector
-        integer,dimension(2),intent(in) :: ierr  !! [n<3 check, size(x)==n check]
-        integer,intent(out)             :: iflag !! status return code
-        logical,intent(out)             :: error
+        character(len=*),intent(in)         :: s
+        integer(ip),intent(in)              :: n
+        real(wp),dimension(:),intent(in)    :: x     !! abcissae vector
+        integer(ip),dimension(2),intent(in) :: ierr  !! [n<3 check, size(x)==n check]
+        integer(ip),intent(out)             :: iflag !! status return code
+        logical,intent(out)                 :: error
 
-        if (n < 3) then
-            iflag = ierr(1)
+        if (n < 3_ip) then
+            iflag = ierr(1_ip)
             error = .true.
         else
             if (size(x)/=n) then
@@ -2233,13 +2238,13 @@
         implicit none
 
         character(len=*),intent(in) :: s
-        integer,intent(in)          :: k
-        integer,intent(in)          :: n
-        integer,intent(in)          :: ierr
-        integer,intent(out)         :: iflag !! status return code
+        integer(ip),intent(in)      :: k
+        integer(ip),intent(in)      :: n
+        integer(ip),intent(in)      :: ierr
+        integer(ip),intent(out)     :: iflag !! status return code
         logical,intent(out)         :: error
 
-        if ((k < 2) .or. (k >= n)) then
+        if ((k < 2_ip) .or. (k >= n)) then
             iflag = ierr
             error = .true.
         else
@@ -2253,17 +2258,17 @@
         implicit none
 
         character(len=*),intent(in)       :: s
-        integer,intent(in)                :: n
+        integer(ip),intent(in)            :: n
         real(wp),dimension(:),intent(in)  :: x
-        integer,intent(in)                :: ierr
-        integer,intent(out)               :: iflag !! status return code
+        integer(ip),intent(in)            :: ierr
+        integer(ip),intent(out)           :: iflag !! status return code
         logical,intent(out)               :: error
 
-        integer :: i
+        integer(ip) :: i
 
         error = .true.
-        do i=2,n
-            if (x(i) <= x(i-1)) then
+        do i=2_ip,n
+            if (x(i) <= x(i-1_ip)) then
                 iflag = ierr
                 return
             end if
@@ -2276,15 +2281,15 @@
 
         implicit none
 
-        character(len=*),intent(in)       :: s
-        integer,intent(in)                :: n
-        integer,intent(in)                :: k
-        real(wp),dimension(:),intent(in)  :: t
-        integer,dimension(2),intent(in)   :: ierr  !! [non-decreasing check, size check]
-        integer,intent(out)               :: iflag !! status return code
-        logical,intent(out)               :: error
+        character(len=*),intent(in)         :: s
+        integer(ip),intent(in)              :: n
+        integer(ip),intent(in)              :: k
+        real(wp),dimension(:),intent(in)    :: t
+        integer(ip),dimension(2),intent(in) :: ierr  !! [non-decreasing check, size check]
+        integer(ip),intent(out)             :: iflag !! status return code
+        logical,intent(out)                 :: error
 
-        integer :: i
+        integer(ip) :: i
 
         error = .true.
 
@@ -2293,9 +2298,9 @@
             return
         end if
 
-        do i=2,n + k
-            if (t(i) < t(i-1))  then
-                iflag = ierr(1)
+        do i=2_ip,n + k
+            if (t(i) < t(i-1_ip))  then
+                iflag = ierr(1_ip)
                 return
             end if
         end do
@@ -2323,43 +2328,43 @@
 
     implicit none
 
-    integer,intent(in)                 :: n
-    integer,intent(in)                 :: k
+    integer(ip),intent(in)             :: n
+    integer(ip),intent(in)             :: k
     real(wp),dimension(n),intent(in)   :: x
     real(wp),dimension(:),intent(out)  :: t
 
-    integer  :: i, j, ipj, npj, ip1, jstrt
+    integer(ip) :: i, j, ipj, npj, ip1, jstrt
     real(wp) :: rnot
 
     !put k knots at each endpoint
     !(shift right endpoints slightly -- see pg 350 of reference)
-    rnot = x(n) + 0.1_wp*( x(n)-x(n-1) )
-    do j=1,k
-        t(j)   = x(1)
+    rnot = x(n) + 0.1_wp*( x(n)-x(n-1_ip) )
+    do j=1_ip,k
+        t(j)   = x(1_ip)
         npj    = n + j
         t(npj) = rnot
     end do
 
     !distribute remaining knots
 
-    if (mod(k,2) == 1)  then
+    if (mod(k,2_ip) == 1_ip)  then
 
         !case of odd k --  knots between data points
 
-        i = (k-1)/2 - k
-        ip1 = i + 1
-        jstrt = k + 1
+        i = (k-1_ip)/2_ip - k
+        ip1 = i + 1_ip
+        jstrt = k + 1_ip
         do j=jstrt,n
             ipj = i + j
-            t(j) = 0.5_wp*( x(ipj) + x(ipj+1) )
+            t(j) = 0.5_wp*( x(ipj) + x(ipj+1_ip) )
         end do
 
     else
 
         !case of even k --  knots at data points
 
-        i = (k/2) - k
-        jstrt = k+1
+        i = (k/2_ip) - k
+        jstrt = k+1_ip
         do j=jstrt,n
             ipj = i + j
             t(j) = x(ipj)
@@ -2384,49 +2389,49 @@
 
     pure subroutine dbtpcf(x,n,fcn,ldf,nf,t,k,bcoef,work,iflag)
 
-    integer,intent(in)                    :: n
-    integer,intent(in)                    :: nf
-    integer,intent(in)                    :: ldf
-    integer,intent(in)                    :: k
+    integer(ip),intent(in)                :: n
+    integer(ip),intent(in)                :: nf
+    integer(ip),intent(in)                :: ldf
+    integer(ip),intent(in)                :: k
     real(wp),dimension(n),intent(in)      :: x
     real(wp),dimension(ldf,nf),intent(in) :: fcn
     real(wp),dimension(*),intent(in)      :: t
     real(wp),dimension(nf,n),intent(out)  :: bcoef
     real(wp),dimension(*),intent(out)     :: work   !! work array of size >= `2*k*(n+1)`
-    integer,intent(out)                   :: iflag  !!   0: no errors
+    integer(ip),intent(out)               :: iflag  !!   0: no errors
                                                     !! 301: n should be >0
 
-    integer :: i, j, m1, m2, iq, iw
+    integer(ip) :: i, j, m1, m2, iq, iw
 
     ! check for null input
 
-    if (nf > 0)  then
+    if (nf > 0_ip)  then
 
         ! partition work array
-        m1 = k - 1
+        m1 = k - 1_ip
         m2 = m1 + k
-        iq = 1 + n
-        iw = iq + m2*n+1
+        iq = 1_ip + n
+        iw = iq + m2*n+1_ip
 
         ! compute b-spline coefficients
 
         ! first data set
 
         call dbintk(x,fcn,t,n,k,work,work(iq),work(iw),iflag)
-        if (iflag == 0) then
-            do i=1,n
-                bcoef(1,i) = work(i)
+        if (iflag == 0_ip) then
+            do i=1_ip,n
+                bcoef(1_ip,i) = work(i)
             end do
 
             !  all remaining data sets by back-substitution
 
-            if (nf == 1)  return
-            do j=2,nf
-                do i=1,n
+            if (nf == 1_ip)  return
+            do j=2_ip,nf
+                do i=1_ip,n
                     work(i) = fcn(i,j)
                 end do
                 call dbnslv(work(iq),m2,n,m1,m1,work)
-                do i=1,n
+                do i=1_ip,n
                     bcoef(j,i) = work(i)
                 end do
             end do
@@ -2434,7 +2439,7 @@
 
     else
         !write(error_unit,'(A)') 'dbtpcf - n should be >0'
-        iflag = 301
+        iflag = 301_ip
     end if
 
     end subroutine dbtpcf
@@ -2481,7 +2486,7 @@
 
     implicit none
 
-    integer,intent(in)                :: n      !! number of data points, n >= k
+    integer(ip),intent(in)            :: n      !! number of data points, n >= k
     real(wp),dimension(n),intent(in)  :: x      !! vector of length n containing data point abscissa
                                                 !! in strictly increasing order.
     real(wp),dimension(n),intent(in)  :: y      !! corresponding vector of length n containing data
@@ -2490,7 +2495,7 @@
                                                 !! since t(1),..,t(k) <= x(1) and t(n+1),..,t(n+k)
                                                 !! >= x(n), this leaves only n-k knots (not
                                                 !! necessarily x(i) values) interior to (x(1),x(n))
-    integer,intent(in)                :: k      !! order of the spline, k >= 1
+    integer(ip),intent(in)            :: k      !! order of the spline, k >= 1
     real(wp),dimension(n),intent(out) :: bcoef  !! a vector of length n containing the b-spline coefficients
     real(wp),dimension(*),intent(out) :: q      !! a work vector of length (2*k-1)*n, containing
                                                 !! the triangular factorization of the coefficient
@@ -2501,7 +2506,7 @@
                                                 !! yy into bcoef and then executing
                                                 !! call dbnslv(q,2k-1,n,k-1,k-1,bcoef)
     real(wp),dimension(*),intent(out) :: work   !! work vector of length 2*k
-    integer,intent(out)               :: iflag  !! *   0: no errors.
+    integer(ip),intent(out)           :: iflag  !! *   0: no errors.
                                                 !! * 100: k does not satisfy k>=1.
                                                 !! * 101: n does not satisfy n>=k.
                                                 !! * 102: x(i) does not satisfy x(i)<x(i+1) for some i.
@@ -2510,71 +2515,71 @@
                                                 !! * 104: the system of solver detects a singular system.
                                                 !! although the theoretical conditions for a solution were satisfied.
 
-    integer :: iwork, i, ilp1mx, j, jj, km1, kpkm2, left,lenq, np1
+    integer(ip) :: iwork, i, ilp1mx, j, jj, km1, kpkm2, left,lenq, np1
     real(wp) :: xi
     logical :: found
 
-    if (k<1) then
+    if (k<1_ip) then
         !write(error_unit,'(A)') 'dbintk - k does not satisfy k>=1'
-        iflag = 100
+        iflag = 100_ip
         return
     end if
 
     if (n<k) then
         !write(error_unit,'(A)') 'dbintk - n does not satisfy n>=k'
-        iflag = 101
+        iflag = 101_ip
         return
     end if
 
-    jj = n - 1
-    if (jj/=0) then
-        do i=1,jj
-            if (x(i)>=x(i+1)) then
+    jj = n - 1_ip
+    if (jj/=0_ip) then
+        do i=1_ip,jj
+            if (x(i)>=x(i+1_ip)) then
                 !write(error_unit,'(A)') 'dbintk - x(i) does not satisfy x(i)<x(i+1) for some i'
-                iflag = 102
+                iflag = 102_ip
                 return
             end if
         end do
     end if
 
-    np1 = n + 1
-    km1 = k - 1
-    kpkm2 = 2*km1
+    np1 = n + 1_ip
+    km1 = k - 1_ip
+    kpkm2 = 2_ip*km1
     left = k
     ! zero out all entries of q
     lenq = n*(k+km1)
-    do i=1,lenq
+    do i=1_ip,lenq
         q(i) = 0.0_wp
     end do
 
     ! loop over i to construct the n interpolation equations
-    do i=1,n
+    do i=1_ip,n
 
         xi = x(i)
         ilp1mx = min(i+k,np1)
-        ! find left in the closed interval (i,i+k-1) such that
-        !         t(left) <= x(i) < t(left+1)
+        ! find left in the closed interval (i,i+k-1_ip) such that
+        !         t(left) <= x(i) < t(left+1_ip)
         ! matrix is singular if this is not possible
         left = max(left,i)
         if (xi<t(left)) then
             !write(error_unit,'(A)') 'dbintk - some abscissa was not in the support of the'//&
             !             ' corresponding basis function and the system is singular'
-            iflag = 103
+            iflag = 103_ip
             return
         end if
         found = .false.
         do
-            found = (xi<t(left+1))
+            found = (xi<t(left+1_ip))
             if (found) exit
-            left = left + 1
+            left = left + 1_ip
             if (left>=ilp1mx) exit
         end do
         if (.not. found) then
-            left = left - 1
-            if (xi>t(left+1)) then
+            left = left - 1_ip
+            if (xi>t(left+1_ip)) then
                 !write(error_unit,'(A)') 'dbintk - some abscissa was not in the support of the'//&
                 !             ' corresponding basis function and the system is singular'
-                iflag = 103
+                iflag = 103_ip
                 return
             end if
         end if
@@ -2583,8 +2588,8 @@
         ! left-k+1,...,left actually might be nonzero. these  k  numbers
         ! are returned, in  bcoef (used for temp.storage here), by the
         ! following
-        call dbspvn(t, k, k, 1, xi, left, bcoef, work, iwork, iflag)
-        if (iflag/=0) return
+        call dbspvn(t, k, k, 1_ip, xi, left, bcoef, work, iwork, iflag)
+        if (iflag/=0_ip) return
 
         ! we therefore want  bcoef(j) = b(left-k+j)(xi) to go into
         ! a(i,left-k+j), i.e., into  q(i-(left+j)+2*k,(left+j)-k) since
@@ -2597,8 +2602,8 @@
         !     i -(left+j) + 2*k + ((left+j) - k-1)*(2*k-1)
         !            = i-left+1 + (left -k)*(2*k-1) + (2*k-2)*j
         ! of q.
-        jj = i - left + 1 + (left-k)*(k+km1)
-        do j=1,k
+        jj = i - left + 1_ip + (left-k)*(k+km1)
+        do j=1_ip,k
             jj = jj + kpkm2
             q(jj) = bcoef(j)
         end do
@@ -2610,15 +2615,15 @@
 
     if (iflag==1) then !success
         ! solve  a*bcoef = y  by backsubstitution
-        do i=1,n
+        do i=1_ip,n
             bcoef(i) = y(i)
         end do
         call dbnslv(q, k+km1, n, km1, km1, bcoef)
-        iflag = 0
+        iflag = 0_ip
     else  !failure
         !write(error_unit,'(A)') 'dbintk - the system of solver detects a singular system'//&
         !             ' although the theoretical conditions for a solution were satisfied'
-        iflag = 104
+        iflag = 104_ip
     end if
 
     end subroutine dbintk
@@ -2685,51 +2690,51 @@
 
     pure subroutine dbnfac(w,nroww,nrow,nbandl,nbandu,iflag)
 
-    integer,intent(in) :: nroww   !! row dimension of the work array w. must be >= nbandl + 1 + nbandu.
-    integer,intent(in) :: nrow    !! matrix order
-    integer,intent(in) :: nbandl  !! number of bands of a below the main diagonal
-    integer,intent(in) :: nbandu  !! number of bands of a above the main diagonal
-    integer,intent(out) :: iflag  !! indicating success(=1) or failure (=2)
+    integer(ip),intent(in) :: nroww   !! row dimension of the work array w. must be >= nbandl + 1 + nbandu.
+    integer(ip),intent(in) :: nrow    !! matrix order
+    integer(ip),intent(in) :: nbandl  !! number of bands of a below the main diagonal
+    integer(ip),intent(in) :: nbandu  !! number of bands of a above the main diagonal
+    integer(ip),intent(out) :: iflag  !! indicating success(=1) or failure (=2)
     real(wp),dimension(nroww,nrow),intent(inout) :: w  !! work array. See header for details.
 
-    integer :: i, ipk, j, jmax, k, kmax, middle, midmk, nrowm1
+    integer(ip) :: i, ipk, j, jmax, k, kmax, middle, midmk, nrowm1
     real(wp) :: factor, pivot
 
-    iflag = 1
-    middle = nbandu + 1   ! w(middle,.) contains the main diagonal of a.
-    nrowm1 = nrow - 1
+    iflag = 1_ip
+    middle = nbandu + 1_ip   ! w(middle,.) contains the main diagonal of a.
+    nrowm1 = nrow - 1_ip
 
-    if (nrowm1 < 0) then
-        iflag = 2
+    if (nrowm1 < 0_ip) then
+        iflag = 2_ip
         return
-    else if (nrowm1 == 0) then
-        if (w(middle,nrow)==0.0_wp) iflag = 2
+    else if (nrowm1 == 0_ip) then
+        if (w(middle,nrow)==0.0_wp) iflag = 2_ip
         return
     end if
 
-    if (nbandl<=0) then
+    if (nbandl<=0_ip) then
         ! a is upper triangular. check that diagonal is nonzero .
-        do i=1,nrowm1
+        do i=1_ip,nrowm1
             if (w(middle,i)==0.0_wp) then
-                iflag = 2
+                iflag = 2_ip
                 return
             end if
         end do
-        if (w(middle,nrow)==0.0_wp) iflag = 2
+        if (w(middle,nrow)==0.0_wp) iflag = 2_ip
         return
     end if
 
-    if (nbandu<=0) then
+    if (nbandu<=0_ip) then
         ! a is lower triangular. check that diagonal is nonzero and
         ! divide each column by its diagonal.
-        do i=1,nrowm1
+        do i=1_ip,nrowm1
             pivot = w(middle,i)
             if (pivot==0.0_wp) then
-                iflag = 2
+                iflag = 2_ip
                 return
             end if
             jmax = min(nbandl,nrow-i)
-            do j=1,jmax
+            do j=1_ip,jmax
                 w(middle+j,i) = w(middle+j,i)/pivot
             end do
         end do
@@ -2737,18 +2742,18 @@
     end if
 
     ! a is not just a triangular matrix. construct lu factorization
-    do i=1,nrowm1
+    do i=1_ip,nrowm1
         ! w(middle,i)  is pivot for i-th step .
         pivot = w(middle,i)
         if (pivot==0.0_wp) then
-            iflag = 2
+            iflag = 2_ip
             return
         end if
         ! jmax is the number of (nonzero) entries in column i
         ! below the diagonal.
         jmax = min(nbandl,nrow-i)
         ! divide each entry in column i below diagonal by pivot.
-        do j=1,jmax
+        do j=1_ip,jmax
             w(middle+j,i) = w(middle+j,i)/pivot
         end do
         ! kmax is the number of (nonzero) entries in row i to
@@ -2756,18 +2761,18 @@
         kmax = min(nbandu,nrow-i)
         ! subtract a(i,i+k)*(i-th column) from (i+k)-th column
         ! (below row i).
-        do k=1,kmax
+        do k=1_ip,kmax
             ipk = i + k
             midmk = middle - k
             factor = w(midmk,ipk)
-            do j=1,jmax
+            do j=1_ip,jmax
                 w(midmk+j,ipk) = w(midmk+j,ipk) - w(middle+j,i)*factor
             end do
         end do
     end do
 
     ! check the last diagonal entry.
-    if (w(middle,nrow)==0.0_wp) iflag = 2
+    if (w(middle,nrow)==0.0_wp) iflag = 2_ip
 
     end subroutine dbnfac
 !*****************************************************************************************
@@ -2790,33 +2795,33 @@
 
     pure subroutine dbnslv(w,nroww,nrow,nbandl,nbandu,b)
 
-    integer,intent(in) :: nroww   !! describes the lu-factorization of a banded matrix a of order `nrow`
-                                  !! as constructed in [[dbnfac]].
-    integer,intent(in) :: nrow    !! describes the lu-factorization of a banded matrix a of order `nrow`
-                                  !! as constructed in [[dbnfac]].
-    integer,intent(in) :: nbandl  !! describes the lu-factorization of a banded matrix a of order `nrow`
-                                  !! as constructed in [[dbnfac]].
-    integer,intent(in) :: nbandu  !! describes the lu-factorization of a banded matrix a of order `nrow`
-                                  !! as constructed in [[dbnfac]].
+    integer(ip),intent(in) :: nroww   !! describes the lu-factorization of a banded matrix a of order `nrow`
+                                      !! as constructed in [[dbnfac]].
+    integer(ip),intent(in) :: nrow    !! describes the lu-factorization of a banded matrix a of order `nrow`
+                                      !! as constructed in [[dbnfac]].
+    integer(ip),intent(in) :: nbandl  !! describes the lu-factorization of a banded matrix a of order `nrow`
+                                      !! as constructed in [[dbnfac]].
+    integer(ip),intent(in) :: nbandu  !! describes the lu-factorization of a banded matrix a of order `nrow`
+                                      !! as constructed in [[dbnfac]].
     real(wp),dimension(nroww,nrow),intent(in) :: w !! describes the lu-factorization of a banded matrix a of
                                                    !! order `nrow` as constructed in [[dbnfac]].
     real(wp),dimension(nrow),intent(inout) :: b  !! * **in**: right side of the system to be solved
                                                  !! * **out**: the solution x, of order nrow
 
-    integer :: i, j, jmax, middle, nrowm1
+    integer(ip) :: i, j, jmax, middle, nrowm1
 
-    middle = nbandu + 1
-    if (nrow/=1) then
+    middle = nbandu + 1_ip
+    if (nrow/=1_ip) then
 
-        nrowm1 = nrow - 1
-        if (nbandl/=0) then
+        nrowm1 = nrow - 1_ip
+        if (nbandl/=0_ip) then
 
             ! forward pass
             ! for i=1,2,...,nrow-1, subtract right side(i)*(i-th column of l)
             !                       from right side (below i-th row).
-            do i=1,nrowm1
+            do i=1_ip,nrowm1
                 jmax = min(nbandl,nrow-i)
-                do j=1,jmax
+                do j=1_ip,jmax
                     b(i+j) = b(i+j) - b(i)*w(middle+j,i)
                 end do
             end do
@@ -2827,10 +2832,10 @@
         ! for i=nrow,nrow-1,...,1, divide right side(i) by i-th diagonal
         !                          entry of u, then subtract right side(i)*(i-th column
         !                          of u) from right side (above i-th row).
-        if (nbandu<=0) then
+        if (nbandu<=0_ip) then
             ! a is lower triangular.
-            do i=1,nrow
-                b(i) = b(i)/w(1,i)
+            do i=1_ip,nrow
+                b(i) = b(i)/w(1_ip,i)
             end do
             return
         end if
@@ -2838,17 +2843,17 @@
         i = nrow
         do
             b(i) = b(i)/w(middle,i)
-            jmax = min(nbandu,i-1)
-            do j=1,jmax
+            jmax = min(nbandu,i-1_ip)
+            do j=1_ip,jmax
                 b(i-j) = b(i-j) - b(i)*w(middle-j,i)
             end do
-            i = i - 1
-            if (i<=1) exit
+            i = i - 1_ip
+            if (i<=1_ip) exit
         end do
 
     end if
 
-    b(1) = b(1)/w(middle,1)
+    b(1_ip) = b(1_ip)/w(middle,1_ip)
 
     end subroutine dbnslv
 !*****************************************************************************************
@@ -2887,70 +2892,70 @@
                                                   !! n = number of b-spline basis functions
                                                   !! n = sum of knot multiplicities-k
                                                   !! dimension t(ileft+jhigh)
-    integer,intent(in)                :: jhigh    !! order of b-spline, 1 <= jhigh <= k
-    integer,intent(in)                :: k        !! highest possible order
-    integer,intent(in)                :: index    !! index = 1 gives basis functions of order jhigh
+    integer(ip),intent(in)            :: jhigh    !! order of b-spline, 1 <= jhigh <= k
+    integer(ip),intent(in)            :: k        !! highest possible order
+    integer(ip),intent(in)            :: index    !! index = 1 gives basis functions of order jhigh
                                                   !!       = 2 denotes previous entry with work, iwork
                                                   !!         values saved for subsequent calls to
                                                   !!         dbspvn.
     real(wp),intent(in)               :: x        !! argument of basis functions, t(k) <= x <= t(n+1)
-    integer,intent(in)                :: ileft    !! largest integer such that t(ileft) <= x < t(ileft+1)
+    integer(ip),intent(in)            :: ileft    !! largest integer such that t(ileft) <= x < t(ileft+1)
     real(wp),dimension(k),intent(out) :: vnikx    !! vector of length k for spline values.
     real(wp),dimension(*),intent(out) :: work     !! a work vector of length 2*k
-    integer,intent(out)               :: iwork    !! a work parameter.  both work and iwork contain
+    integer(ip),intent(out)           :: iwork    !! a work parameter.  both work and iwork contain
                                                   !! information necessary to continue for index = 2.
                                                   !! when index = 1 exclusively, these are scratch
                                                   !! variables and can be used for other purposes.
-    integer,intent(out)               :: iflag    !!   0: no errors
+    integer(ip),intent(out)           :: iflag    !!   0: no errors
                                                   !! 201: k does not satisfy k>=1
                                                   !! 202: jhigh does not satisfy 1<=jhigh<=k
                                                   !! 203: index is not 1 or 2
                                                   !! 204: x does not satisfy t(ileft)<=x<=t(ileft+1)
 
-    integer :: imjp1, ipj, jp1, jp1ml, l
+    integer(ip) :: imjp1, ipj, jp1, jp1ml, l
     real(wp) :: vm, vmprev
 
     ! content of j, deltam, deltap is expected unchanged between calls.
     ! work(i) = deltap(i),
     ! work(k+i) = deltam(i), i = 1,k
 
-    if (k<1) then
+    if (k<1_ip) then
         !write(error_unit,'(A)') 'dbspvn - k does not satisfy k>=1'
-        iflag = 201
+        iflag = 201_ip
         return
     end if
-    if (jhigh>k .or. jhigh<1) then
+    if (jhigh>k .or. jhigh<1_ip) then
         !write(error_unit,'(A)') 'dbspvn - jhigh does not satisfy 1<=jhigh<=k'
-        iflag = 202
+        iflag = 202_ip
         return
     end if
-    if (index<1 .or. index>2) then
+    if (index<1_ip .or. index>2_ip) then
         !write(error_unit,'(A)') 'dbspvn - index is not 1 or 2'
-        iflag = 203
+        iflag = 203_ip
         return
     end if
-    if (x<t(ileft) .or. x>t(ileft+1)) then
+    if (x<t(ileft) .or. x>t(ileft+1_ip)) then
         !write(error_unit,'(A)') 'dbspvn - x does not satisfy t(ileft)<=x<=t(ileft+1)'
-        iflag = 204
+        iflag = 204_ip
         return
     end if
 
-    iflag = 0
+    iflag = 0_ip
 
-    if (index==1) then
-        iwork = 1
-        vnikx(1) = 1.0_wp
+    if (index==1_ip) then
+        iwork = 1_ip
+        vnikx(1_ip) = 1.0_wp
         if (iwork>=jhigh) return
     end if
 
     do
         ipj = ileft + iwork
         work(iwork) = t(ipj) - x
-        imjp1 = ileft - iwork + 1
+        imjp1 = ileft - iwork + 1_ip
         work(k+iwork) = x - t(imjp1)
         vmprev = 0.0_wp
-        jp1 = iwork + 1
-        do l=1,iwork
+        jp1 = iwork + 1_ip
+        do l=1_ip,iwork
             jp1ml = jp1 - l
             vm = vnikx(l)/(work(l)+work(k+jp1ml))
             vnikx(l) = vm*work(l) + vmprev
@@ -2994,22 +2999,22 @@
     implicit none
 
     real(wp),intent(out)             :: val     !! the interpolated value
-    integer,intent(in)               :: n       !! number of b-spline coefficients.
+    integer(ip),intent(in)           :: n       !! number of b-spline coefficients.
                                                 !! (sum of knot multiplicities-`k`)
     real(wp),dimension(:),intent(in) :: t       !! knot vector of length `n+k`
     real(wp),dimension(n),intent(in) :: a       !! b-spline coefficient vector of length `n`
-    integer,intent(in)               :: k       !! order of the b-spline, `k >= 1`
-    integer,intent(in)               :: ideriv  !! order of the derivative, `0 <= ideriv <= k-1`.
+    integer(ip),intent(in)           :: k       !! order of the b-spline, `k >= 1`
+    integer(ip),intent(in)           :: ideriv  !! order of the derivative, `0 <= ideriv <= k-1`.
                                                 !! `ideriv = 0` returns the b-spline value
     real(wp),intent(in)              :: x       !! argument, `t(k) <= x <= t(n+1)`
-    integer,intent(inout)            :: inbv    !! an initialization parameter which must be set
+    integer(ip),intent(inout)        :: inbv    !! an initialization parameter which must be set
                                                 !! to 1 the first time [[dbvalu]] is called.
                                                 !! `inbv` contains information for efficient processing
                                                 !! after the initial call and `inbv` must not
                                                 !! be changed by the user.  distinct splines require
                                                 !! distinct `inbv` parameters.
     real(wp),dimension(:),intent(inout) :: work !! work vector of length at least `3*k`
-    integer,intent(out)              :: iflag   !! status flag:
+    integer(ip),intent(out)          :: iflag   !! status flag:
                                                 !!
                                                 !! * 0: no errors
                                                 !! * 401: `k` does not satisfy `k` \( \ge \) 1
@@ -3021,7 +3026,7 @@
     logical,intent(in),optional :: extrap   !! if extrapolation is allowed
                                             !! (if not present, default is False)
 
-    integer :: i,iderp1,ihi,ihmkmj,ilo,imk,imkpj,ipj,&
+    integer(ip) :: i,iderp1,ihi,ihmkmj,ilo,imk,imkpj,ipj,&
                ip1,ip1mj,j,jj,j1,j2,kmider,kmj,km1,kpk,mflag
     real(wp) :: fkmj
     real(wp) :: xt
@@ -3029,18 +3034,18 @@
 
     val = 0.0_wp
 
-    if (k<1) then
-        iflag = 401  ! dbvalu - k does not satisfy k>=1
+    if (k<1_ip) then
+        iflag = 401_ip  ! dbvalu - k does not satisfy k>=1
         return
     end if
 
     if (n<k) then
-        iflag = 402  ! dbvalu - n does not satisfy n>=k
+        iflag = 402_ip  ! dbvalu - n does not satisfy n>=k
         return
     end if
 
-    if (ideriv<0 .or. ideriv>=k) then
-        iflag = 403  ! dbvalu - ideriv does not satisfy 0<=ideriv<k
+    if (ideriv<0_ip .or. ideriv>=k) then
+        iflag = 403_ip  ! dbvalu - ideriv does not satisfy 0<=ideriv<k
         return
     end if
 
@@ -3053,8 +3058,8 @@
     ! make a temp copy of x (for computing the
     ! interval) in case extrapolation is allowed
     if (extrapolation_allowed) then
-        if (x<t(1)) then
-            xt = t(1)
+        if (x<t(1_ip)) then
+            xt = t(1_ip)
         else if(x>t(n+k)) then
             xt = t(n+k)
         else
@@ -3069,26 +3074,26 @@
     ! find *i* in (k,n) such that t(i) <= x < t(i+1)
     ! (or, <= t(i+1) if t(i) < t(i+1) = t(n+1)).
 
-    km1 = k - 1
+    km1 = k - 1_ip
     call dintrv(t, n+1, xt, inbv, i, mflag)
     if (xt<t(k)) then
-        iflag = 404  ! dbvalu - x is not greater than or equal to t(k)
+        iflag = 404_ip  ! dbvalu - x is not greater than or equal to t(k)
         return
     end if
 
-    if (mflag/=0) then
+    if (mflag/=0_ip) then
 
         if (xt>t(i)) then
-            iflag = 405  ! dbvalu - x is not less than or equal to t(n+1)
+            iflag = 405_ip  ! dbvalu - x is not less than or equal to t(n+1)
             return
         end if
 
         do
             if (i==k) then
-                iflag = 406  ! dbvalu - a left limiting value cannot be obtained at t(k)
+                iflag = 406_ip  ! dbvalu - a left limiting value cannot be obtained at t(k)
                 return
             end if
-            i = i - 1
+            i = i - 1_ip
             if (xt/=t(i)) exit
         end do
 
@@ -3098,19 +3103,19 @@
     ! work(i) = aj(i), work(k+i) = dp(i), work(k+k+i) = dm(i), i=1.k
 
     imk = i - k
-    do j=1,k
+    do j=1_ip,k
         imkpj = imk + j
         work(j) = a(imkpj)
     end do
 
-    if (ideriv/=0) then
-        do j=1,ideriv
+    if (ideriv/=0_ip) then
+        do j=1_ip,ideriv
             kmj = k - j
             fkmj = real(kmj,wp)
-            do jj=1,kmj
+            do jj=1_ip,kmj
                 ihi = i + jj
                 ihmkmj = ihi - kmj
-                work(jj) = (work(jj+1)-work(jj))/(t(ihi)-t(ihmkmj))*fkmj
+                work(jj) = (work(jj+1_ip)-work(jj))/(t(ihi)-t(ihmkmj))*fkmj
             end do
         end do
     end if
@@ -3119,32 +3124,32 @@
     ! given its relevant b-spline coeff. in aj(1),...,aj(k-ideriv).
 
     if (ideriv/=km1) then
-        ip1 = i + 1
+        ip1 = i + 1_ip
         kpk = k + k
-        j1 = k + 1
-        j2 = kpk + 1
-        do j=1,kmider
+        j1 = k + 1_ip
+        j2 = kpk + 1_ip
+        do j=1_ip,kmider
             ipj = i + j
             work(j1) = t(ipj) - x
             ip1mj = ip1 - j
             work(j2) = x - t(ip1mj)
-            j1 = j1 + 1
-            j2 = j2 + 1
+            j1 = j1 + 1_ip
+            j2 = j2 + 1_ip
         end do
-        iderp1 = ideriv + 1
+        iderp1 = ideriv + 1_ip
         do j=iderp1,km1
             kmj = k - j
             ilo = kmj
-            do jj=1,kmj
-                work(jj) = (work(jj+1)*work(kpk+ilo)+work(jj)*&
+            do jj=1_ip,kmj
+                work(jj) = (work(jj+1_ip)*work(kpk+ilo)+work(jj)*&
                             work(k+jj))/(work(kpk+ilo)+work(k+jj))
                 ilo = ilo - 1
             end do
         end do
     end if
 
-    iflag = 0
-    val = work(1)
+    iflag = 0_ip
+    val = work(1_ip)
 
     end subroutine dbvalu
 !*****************************************************************************************
@@ -3177,57 +3182,57 @@
 
     implicit none
 
-    integer,intent(in)                 :: lxt    !! length of the `xt` vector
+    integer(ip),intent(in)             :: lxt    !! length of the `xt` vector
     real(wp),dimension(lxt),intent(in) :: xt     !! a knot or break point vector of length `lxt`
     real(wp),intent(in)                :: xx     !! argument
-    integer,intent(inout)              :: ilo    !! an initialization parameter which must be set
+    integer(ip),intent(inout)          :: ilo    !! an initialization parameter which must be set
                                                  !! to 1 the first time the spline array `xt` is
                                                  !! processed by dintrv. `ilo` contains information for
                                                  !! efficient processing after the initial call and `ilo`
                                                  !! must not be changed by the user.  distinct splines
                                                  !! require distinct `ilo` parameters.
-    integer,intent(out)                :: ileft  !! largest integer satisfying `xt(ileft)` \( \le \) `x`
-    integer,intent(out)                :: mflag  !! signals when `x` lies out of bounds
+    integer(ip),intent(out)            :: ileft  !! largest integer satisfying `xt(ileft)` \( \le \) `x`
+    integer(ip),intent(out)            :: mflag  !! signals when `x` lies out of bounds
     logical,intent(in),optional        :: extrap !! if extrapolation is allowed
                                                  !! (if not present, default is False)
 
-    integer :: ihi, istep, middle
+    integer(ip) :: ihi, istep, middle
     real(wp) :: x
 
-    x = get_temp_x_for_extrap(xx,xt(1),xt(lxt),extrap)
+    x = get_temp_x_for_extrap(xx,xt(1_ip),xt(lxt),extrap)
 
-    ihi = ilo + 1
+    ihi = ilo + 1_ip
     if ( ihi>=lxt ) then
         if ( x>=xt(lxt) ) then
-            mflag = -2
+            mflag = -2_ip
             ileft = lxt
             return
         end if
         if ( lxt<=1 ) then
-            mflag = -1
-            ileft = 1
+            mflag = -1_ip
+            ileft = 1_ip
             return
         end if
-        ilo = lxt - 1
+        ilo = lxt - 1_ip
         ihi = lxt
     end if
 
     if ( x>=xt(ihi) ) then
 
         ! now x >= xt(ilo). find upper bound
-        istep = 1
+        istep = 1_ip
         do
             ilo = ihi
             ihi = ilo + istep
             if ( ihi>=lxt ) then
                 if ( x>=xt(lxt) ) then
-                    mflag = -2
+                    mflag = -2_ip
                     ileft = lxt
                     return
                 end if
                 ihi = lxt
             else if ( x>=xt(ihi) ) then
-                istep = istep*2
+                istep = istep*2_ip
                 cycle
             end if
             exit
@@ -3236,24 +3241,24 @@
     else
 
         if ( x>=xt(ilo) ) then
-            mflag = 0
+            mflag = 0_ip
             ileft = ilo
             return
         end if
         ! now x <= xt(ihi). find lower bound
-        istep = 1
+        istep = 1_ip
         do
             ihi = ilo
             ilo = ihi - istep
-            if ( ilo<=1 ) then
-                ilo = 1
-                if ( x<xt(1) ) then
-                    mflag = -1
-                    ileft = 1
+            if ( ilo<=1_ip ) then
+                ilo = 1_ip
+                if ( x<xt(1_ip) ) then
+                    mflag = -1_ip
+                    ileft = 1_ip
                     return
                 end if
             else if ( x<xt(ilo) ) then
-                istep = istep*2
+                istep = istep*2_ip
                 cycle
             end if
             exit
@@ -3263,9 +3268,9 @@
 
     ! now xt(ilo) <= x < xt(ihi). narrow the interval
     do
-        middle = (ilo+ihi)/2
+        middle = (ilo+ihi)/2_ip
         if ( middle==ilo ) then
-            mflag = 0
+            mflag = 0_ip
             ileft = ilo
             return
         end if
@@ -3321,15 +3326,15 @@
 
     real(wp),dimension(:),intent(in)    :: t       !! knot array of length `n+k`
     real(wp),dimension(:),intent(in)    :: bcoef   !! b-spline coefficient array of length `n`
-    integer,intent(in)                  :: n       !! length of coefficient array
-    integer,intent(in)                  :: k       !! order of b-spline, `1 <= k <= 20`
+    integer(ip),intent(in)              :: n       !! length of coefficient array
+    integer(ip),intent(in)              :: k       !! order of b-spline, `1 <= k <= 20`
     real(wp),intent(in)                 :: x1      !! end point of quadrature interval
                                                    !! in `t(k) <= x <= t(n+1)`
     real(wp),intent(in)                 :: x2      !! end point of quadrature interval
                                                    !! in `t(k) <= x <= t(n+1)`
     real(wp),intent(out)                :: bquad   !! integral of the b-spline over (`x1`,`x2`)
     real(wp),dimension(:),intent(inout) :: work    !! work vector of length `3*k`
-    integer,intent(out)                 :: iflag   !! status flag:
+    integer(ip),intent(out)             :: iflag   !! status flag:
                                                    !!
                                                    !! * 0: no errors
                                                    !! * 901: `k` does not satisfy `1<=k<=20`
@@ -3337,7 +3342,7 @@
                                                    !! * 903: `x1` or `x2` or both do
                                                    !!   not satisfy `t(k)<=x<=t(n+1)`
 
-    integer :: i,il1,il2,ilo,inbv,jf,left,m,mf,mflag,npk,np1
+    integer(ip) :: i,il1,il2,ilo,inbv,jf,left,m,mf,mflag,npk,np1
     real(wp) :: a,aa,b,bb,bma,bpa,c1,gx,q,ta,tb,y1,y2
     real(wp),dimension(5) :: s  !! sum
 
@@ -3431,67 +3436,67 @@
         &18647480566044117862086478449236378557180717569208295026105115288152794&
         &421677_wp]
 
-    iflag = 0
+    iflag = 0_ip
     bquad = 0.0_wp
 
-    if ( k<1 .or. k>20 ) then
+    if ( k<1_ip .or. k>20_ip ) then
 
-        iflag = 901 ! error return
+        iflag = 901_ip ! error return
 
     else if ( n<k ) then
 
-        iflag = 902 ! error return
+        iflag = 902_ip ! error return
 
     else
 
         aa = min(x1,x2)
         bb = max(x1,x2)
         if ( aa>=t(k) ) then
-            np1 = n + 1
+            np1 = n + 1_ip
             if ( bb<=t(np1) ) then
             if ( aa==bb ) return
             npk = n + k
             ! selection of 2, 6, or 10 point gauss formula
-            jf = 0
-            mf = 1
-            if ( k>4 ) then
-                jf = 1
-                mf = 3
-                if ( k>12 ) then
-                    jf = 4
-                    mf = 5
+            jf = 0_ip
+            mf = 1_ip
+            if ( k>4_ip ) then
+                jf = 1_ip
+                mf = 3_ip
+                if ( k>12_ip ) then
+                    jf = 4_ip
+                    mf = 5_ip
                 end if
             end if
-            do i = 1 , mf
+            do i = 1_ip , mf
                 s(i) = 0.0_wp
             end do
-            ilo = 1
-            inbv = 1
+            ilo = 1_ip
+            inbv = 1_ip
             call dintrv(t,npk,aa,ilo,il1,mflag)
             call dintrv(t,npk,bb,ilo,il2,mflag)
             if ( il2>=np1 ) il2 = n
             do left = il1 , il2
                 ta = t(left)
-                tb = t(left+1)
+                tb = t(left+1_ip)
                 if ( ta/=tb ) then
                     a = max(aa,ta)
                     b = min(bb,tb)
                     bma = 0.5_wp*(b-a)
                     bpa = 0.5_wp*(b+a)
-                    do m = 1 , mf
+                    do m = 1_ip , mf
                         c1 = bma*gpts(jf+m)
                         gx = -c1 + bpa
-                        call dbvalu(t,bcoef,n,k,0,gx,inbv,work,iflag,y2)
-                        if (iflag/=0) return
+                        call dbvalu(t,bcoef,n,k,0_ip,gx,inbv,work,iflag,y2)
+                        if (iflag/=0_ip) return
                         gx = c1 + bpa
-                        call dbvalu(t,bcoef,n,k,0,gx,inbv,work,iflag,y1)
-                        if (iflag/=0) return
+                        call dbvalu(t,bcoef,n,k,0_ip,gx,inbv,work,iflag,y1)
+                        if (iflag/=0_ip) return
                         s(m) = s(m) + (y1+y2)*bma
                     end do
                 end if
             end do
             q = 0.0_wp
-            do m = 1 , mf
+            do m = 1_ip , mf
                 q = q + gwts(jf+m)*s(m)
             end do
             if ( x1>x2 ) q = -q
@@ -3500,7 +3505,7 @@
             end if
         end if
 
-        iflag = 903 ! error return
+        iflag = 903_ip ! error return
 
     end if
 
@@ -3543,11 +3548,11 @@
 
     procedure(b1fqad_func)              :: f      !! external function of one argument for the
                                                   !! integrand `bf(x)=f(x)*dbvalu(t,bcoef,n,k,id,x,inbv,work)`
-    integer,intent(in)                  :: n      !! length of coefficient array
-    integer,intent(in)                  :: k      !! order of b-spline, `k >= 1`
+    integer(ip),intent(in)              :: n      !! length of coefficient array
+    integer(ip),intent(in)              :: k      !! order of b-spline, `k >= 1`
     real(wp),dimension(n+k),intent(in)  :: t      !! knot array
     real(wp),dimension(n),intent(in)    :: bcoef  !! coefficient array
-    integer,intent(in)                  :: id     !! order of the spline derivative, `0 <= id <= k-1`
+    integer(ip),intent(in)              :: id     !! order of the spline derivative, `0 <= id <= k-1`
                                                   !! `id=0` gives the spline function
     real(wp),intent(in)                 :: x1     !! left point of quadrature interval in `t(k) <= x <= t(n+1)`
     real(wp),intent(in)                 :: x2     !! right point of quadrature interval in `t(k) <= x <= t(n+1)`
@@ -3557,7 +3562,7 @@
                                                   !! the machine
     real(wp),intent(out)                :: quad   !! integral of `bf(x)` on `(x1,x2)`
     real(wp),dimension(:),intent(inout) :: work   !! work vector of length `3*k`
-    integer,intent(out)                 :: iflag  !! status flag:
+    integer(ip),intent(out)             :: iflag  !! status flag:
                                                   !!
                                                   !! * 0: no errors
                                                   !! * 1001: `k` does not satisfy `k>=1`
@@ -3568,43 +3573,43 @@
                                                   !! * 1005: `tol` is less than `dtol`
                                                   !!   or greater than 0.1
 
-    integer :: inbv,ilo,il1,il2,left,mflag,npk,np1
+    integer(ip) :: inbv,ilo,il1,il2,left,mflag,npk,np1
     real(wp) :: a,aa,ans,b,bb,q,ta,tb,err
 
     real(wp),parameter :: min_tol = max(epsilon(1.0_wp),1.0e-300_wp) !! minimum allowed `tol`
 
-    iflag = 0
+    iflag = 0_ip
     quad = 0.0_wp
     err = tol
-    if ( k<1 ) then
-        iflag = 1001     ! error
+    if ( k<1_ip ) then
+        iflag = 1001_ip     ! error
     elseif ( n<k ) then
-        iflag = 1002     ! error
-    elseif ( id<0 .or. id>=k ) then
-        iflag = 1003     ! error
+        iflag = 1002_ip     ! error
+    elseif ( id<0_ip .or. id>=k ) then
+        iflag = 1003_ip     ! error
     else
         if ( tol>=min_tol .and. tol<=0.1_wp ) then
             aa = min(x1,x2)
             bb = max(x1,x2)
             if ( aa>=t(k) ) then
-                np1 = n + 1
+                np1 = n + 1_ip
                 if ( bb<=t(np1) ) then
                     if ( aa==bb ) return
                     npk = n + k
-                    ilo = 1
+                    ilo = 1_ip
                     call dintrv(t,npk,aa,ilo,il1,mflag)
                     call dintrv(t,npk,bb,ilo,il2,mflag)
                     if ( il2>=np1 ) il2 = n
-                    inbv = 1
+                    inbv = 1_ip
                     q = 0.0_wp
                     do left = il1 , il2
                         ta = t(left)
-                        tb = t(left+1)
+                        tb = t(left+1_ip)
                         if ( ta/=tb ) then
                             a = max(aa,ta)
                             b = min(bb,tb)
                             call dbsgq8(f,t,bcoef,n,k,id,a,b,inbv,err,ans,iflag,work)
-                            if ( iflag/=0 .and. iflag/=1101 ) return
+                            if ( iflag/=0_ip .and. iflag/=1101_ip ) return
                             q = q + ans
                         end if
                     end do
@@ -3612,10 +3617,10 @@
                     quad = q
                 end if
             else
-                iflag = 1004  ! error
+                iflag = 1004_ip  ! error
             end if
         else
-            iflag = 1005  ! error
+            iflag = 1005_ip  ! error
         end if
     end if
 
@@ -3650,14 +3655,14 @@
 
     procedure(b1fqad_func)              :: fun     !! name of external function of one
                                                    !! argument which multiplies [[dbvalu]].
-    integer,intent(in)                  :: n       !! number of b-coefficients for [[dbvalu]]
-    integer,intent(in)                  :: kk      !! order of the spline, `kk>=1`
+    integer(ip),intent(in)              :: n       !! number of b-coefficients for [[dbvalu]]
+    integer(ip),intent(in)              :: kk      !! order of the spline, `kk>=1`
     real(wp),dimension(:),intent(in)    :: xt      !! knot array for [[dbvalu]]
     real(wp),dimension(n),intent(in)    :: bc      !! b-coefficient array for [[dbvalu]]
-    integer,intent(in)                  :: id      !! Order of the spline derivative, `0<=id<=kk-1`
+    integer(ip),intent(in)              :: id      !! Order of the spline derivative, `0<=id<=kk-1`
     real(wp),intent(in)                 :: a       !! lower limit of integral
     real(wp),intent(in)                 :: b       !! upper limit of integral (may be less than `a`)
-    integer,intent(inout)               :: inbv    !! initialization parameter for [[dbvalu]]
+    integer(ip),intent(inout)           :: inbv    !! initialization parameter for [[dbvalu]]
     real(wp),intent(inout)              :: err     !! **IN:** is a requested pseudorelative error
                                                    !! tolerance.  normally pick a value of
                                                    !! `abs(err)<1e-3`.  `ans` will normally
@@ -3673,7 +3678,7 @@
                                                    !! to the user and should not be used as a
                                                    !! correction to the computed integral.
     real(wp),intent(out)                :: ans     !! computed value of integral
-    integer,intent(out)                 :: iflag   !! a status code:
+    integer(ip),intent(out)             :: iflag   !! a status code:
                                                    !!
                                                    !! * 0: `ans` most likely meets requested
                                                    !!   error tolerance, or `a=b`.
@@ -3684,26 +3689,26 @@
                                                    !!   requested error tolerance.
     real(wp),dimension(:),intent(inout) :: work    !! work vector of length `3*k` for [[dbvalu]]
 
-    integer :: k,l,lmn,lmx,mxl,nbits,nib,nlmx
+    integer(ip) :: k,l,lmn,lmx,mxl,nbits,nib,nlmx
     real(wp) :: ae,anib,area,c,ce,ee,ef,eps,est,gl,glr,tol,vr,x
-    integer,dimension(60)  :: lr
+    integer(ip),dimension(60)  :: lr
     real(wp),dimension(60) :: aa,hh,vl,gr
 
-    integer,parameter  :: i1mach14 = digits(1.0_wp)            !! i1mach(14)
-    real(wp),parameter :: d1mach5  = log10(real(radix(x),wp))  !! d1mach(5)
-    real(wp),parameter :: ln2      = log(2.0_wp)               !! 0.69314718d0
-    real(wp),parameter :: sq2      = sqrt(2.0_wp)
-    integer,parameter  :: nlmn     = 1
-    integer,parameter  :: kmx      = 5000
-    integer,parameter  :: kml      = 6
+    integer(ip),parameter  :: i1mach14 = digits(1.0_wp)            !! i1mach(14)
+    real(wp),parameter     :: d1mach5  = log10(real(radix(x),wp))  !! d1mach(5)
+    real(wp),parameter     :: ln2      = log(2.0_wp)               !! 0.69314718d0
+    real(wp),parameter     :: sq2      = sqrt(2.0_wp)
+    integer(ip),parameter  :: nlmn     = 1
+    integer(ip),parameter  :: kmx      = 5000
+    integer(ip),parameter  :: kml      = 6
 
     ! initialize
-    inbv  = 1
-    iflag = 0
+    inbv  = 1_ip
+    iflag = 0_ip
     k     = i1mach14
     anib  = d1mach5*k/0.30102000_wp
-    nbits = int(anib)
-    nlmx  = min((nbits*5)/8,60)
+    nbits = int(anib,ip)
+    nlmx  = min((nbits*5_ip)/8_ip,60_ip)
     ans   = 0.0_wp
     ce    = 0.0_wp
 
@@ -3721,12 +3726,12 @@
                         return
                     else
                         anib = 0.5_wp - log(c)/ln2
-                        nib = int(anib)
-                        lmx = min(nlmx,nbits-nib-7)
-                        if ( lmx<1 ) then
+                        nib = int(anib,ip)
+                        lmx = min(nlmx,nbits-nib-7_ip)
+                        if ( lmx<1_ip ) then
                             ! a and b are too nearly equal
                             ! to allow normal integration
-                            iflag = 1101
+                            iflag = 1101_ip
                             if ( err<0.0_wp ) err = ce
                             return
                         else
@@ -3739,25 +3744,25 @@
         tol = max(abs(err),2.0_wp**(5-nbits))/2.0_wp
         if ( err==0.0_wp ) tol = sqrt(epsilon(1.0_wp))
         eps = tol
-        hh(1) = (b-a)/4.0_wp
-        aa(1) = a
-        lr(1) = 1
-        l = 1
+        hh(1_ip) = (b-a)/4.0_wp
+        aa(1_ip) = a
+        lr(1_ip) = 1_ip
+        l = 1_ip
         call g8(aa(l)+2.0_wp*hh(l),2.0_wp*hh(l),est,iflag)
-        if (iflag/=0) return
-        k = 8
+        if (iflag/=0_ip) return
+        k = 8_ip
         area = abs(est)
         ef = 0.5_wp
-        mxl = 0
+        mxl = 0_ip
     end if
 
     do
         ! compute refined estimates, estimate the error, etc.
         call g8(aa(l)+hh(l),hh(l),gl,iflag)
-        if (iflag/=0) return
+        if (iflag/=0_ip) return
         call g8(aa(l)+3.0_wp*hh(l),hh(l),gr(l),iflag)
-        if (iflag/=0) return
-        k = k + 16
+        if (iflag/=0_ip) return
+        k = k + 16_ip
         area = area + (abs(gl)+abs(gr(l))-abs(est))
         glr = gl + gr(l)
         ee = abs(est-glr)*ef
@@ -3766,49 +3771,49 @@
             ! consider the left half of this level
             if ( k>kmx ) lmx = kml
             if ( l>=lmx ) then
-                mxl = 1
+                mxl = 1_ip
             else
-                l = l + 1
+                l = l + 1_ip
                 eps = eps*0.5_wp
                 ef = ef/sq2
                 hh(l) = hh(l-1)*0.5_wp
-                lr(l) = -1
-                aa(l) = aa(l-1)
+                lr(l) = -1_ip
+                aa(l) = aa(l-1_ip)
                 est = gl
                 cycle
             end if
         end if
         ce = ce + (est-glr)
-        if ( lr(l)<=0 ) then
+        if ( lr(l)<=0_ip ) then
             ! proceed to right half at this level
             vl(l) = glr
         else
             ! return one level
             vr = glr
             do
-                if ( l<=1 ) then
+                if ( l<=1_ip ) then
                     ! exit
                     ans = vr
-                    if ( (mxl/=0) .and. (abs(ce)>2.0_wp*tol*area) ) then
-                        iflag = 1102
+                    if ( (mxl/=0_ip) .and. (abs(ce)>2.0_wp*tol*area) ) then
+                        iflag = 1102_ip
                     end if
                     if ( err<0.0_wp ) err = ce
                     return
                 else
-                    l = l - 1
+                    l = l - 1_ip
                     eps = eps*2.0_wp
                     ef = ef*sq2
                     if ( lr(l)<=0 ) then
-                        vl(l) = vl(l+1) + vr
+                        vl(l) = vl(l+1_ip) + vr
                         exit
                     else
-                        vr = vl(l+1) + vr
+                        vr = vl(l+1_ip) + vr
                     end if
                 end if
             end do
         end if
-        est = gr(l-1)
-        lr(l) = 1
+        est = gr(l-1_ip)
+        lr(l) = 1_ip
         aa(l) = aa(l) + 4.0_wp*hh(l)
     end do
 
@@ -3826,10 +3831,10 @@
 
         implicit none
 
-        real(wp),intent(in)  :: x
-        real(wp),intent(in)  :: h
-        real(wp),intent(out) :: res
-        integer,intent(out)  :: iflag
+        real(wp),intent(in)     :: x
+        real(wp),intent(in)     :: h
+        real(wp),intent(out)    :: res
+        integer(ip),intent(out) :: iflag
 
         real(wp),dimension(8) :: f
         real(wp),dimension(8) :: v
@@ -3886,28 +3891,28 @@
 
         res = 0.0_wp
 
-        v(1) = x-x1*h
-        v(2) = x+x1*h
-        v(3) = x-x2*h
-        v(4) = x+x2*h
-        v(5) = x-x3*h
-        v(6) = x+x3*h
-        v(7) = x-x4*h
-        v(8) = x+x4*h
+        v(1_ip) = x-x1*h
+        v(2_ip) = x+x1*h
+        v(3_ip) = x-x2*h
+        v(4_ip) = x+x2*h
+        v(5_ip) = x-x3*h
+        v(6_ip) = x+x3*h
+        v(7_ip) = x-x4*h
+        v(8_ip) = x+x4*h
 
-        call dbvalu(xt,bc,n,kk,id,v(1),inbv,work,iflag,f(1)); if (iflag/=0) return
-        call dbvalu(xt,bc,n,kk,id,v(2),inbv,work,iflag,f(2)); if (iflag/=0) return
-        call dbvalu(xt,bc,n,kk,id,v(3),inbv,work,iflag,f(3)); if (iflag/=0) return
-        call dbvalu(xt,bc,n,kk,id,v(4),inbv,work,iflag,f(4)); if (iflag/=0) return
-        call dbvalu(xt,bc,n,kk,id,v(5),inbv,work,iflag,f(5)); if (iflag/=0) return
-        call dbvalu(xt,bc,n,kk,id,v(6),inbv,work,iflag,f(6)); if (iflag/=0) return
-        call dbvalu(xt,bc,n,kk,id,v(7),inbv,work,iflag,f(7)); if (iflag/=0) return
-        call dbvalu(xt,bc,n,kk,id,v(8),inbv,work,iflag,f(8)); if (iflag/=0) return
+        call dbvalu(xt,bc,n,kk,id,v(1_ip),inbv,work,iflag,f(1_ip)); if (iflag/=0_ip) return
+        call dbvalu(xt,bc,n,kk,id,v(2_ip),inbv,work,iflag,f(2_ip)); if (iflag/=0_ip) return
+        call dbvalu(xt,bc,n,kk,id,v(3_ip),inbv,work,iflag,f(3_ip)); if (iflag/=0_ip) return
+        call dbvalu(xt,bc,n,kk,id,v(4_ip),inbv,work,iflag,f(4_ip)); if (iflag/=0_ip) return
+        call dbvalu(xt,bc,n,kk,id,v(5_ip),inbv,work,iflag,f(5_ip)); if (iflag/=0_ip) return
+        call dbvalu(xt,bc,n,kk,id,v(6_ip),inbv,work,iflag,f(6_ip)); if (iflag/=0_ip) return
+        call dbvalu(xt,bc,n,kk,id,v(7_ip),inbv,work,iflag,f(7_ip)); if (iflag/=0_ip) return
+        call dbvalu(xt,bc,n,kk,id,v(8_ip),inbv,work,iflag,f(8_ip)); if (iflag/=0_ip) return
 
-        res = h*((w1*(fun(v(1))*f(1) + fun(v(2))*f(2))  + &
-                  w2*(fun(v(3))*f(3) + fun(v(4))*f(4))) + &
-                 (w3*(fun(v(5))*f(5) + fun(v(6))*f(6))  + &
-                  w4*(fun(v(7))*f(7) + fun(v(8))*f(8))))
+        res = h*((w1*(fun(v(1_ip))*f(1_ip) + fun(v(2_ip))*f(2_ip))  + &
+                  w2*(fun(v(3_ip))*f(3_ip) + fun(v(4_ip))*f(4_ip))) + &
+                 (w3*(fun(v(5_ip))*f(5_ip) + fun(v(6_ip))*f(6_ip))  + &
+                  w4*(fun(v(7_ip))*f(7_ip) + fun(v(8_ip))*f(8_ip))))
 
         end subroutine g8
 
@@ -3969,119 +3974,119 @@
 
     implicit none
 
-    integer,intent(in)           :: iflag  !! return code from one of the routines
+    integer(ip),intent(in)       :: iflag  !! return code from one of the routines
     character(len=:),allocatable :: msg    !! status message associated with the flag
 
     character(len=10) :: istr   !! for integer to string conversion
-    integer           :: istat  !! for write statement
+    integer(ip)       :: istat  !! for write statement
 
     select case (iflag)
 
-    case(  0); msg='Successful execution'
+    case(  0_ip); msg='Successful execution'
 
-    case( -1); msg='Error in dintrv: x < xt(1)'
-    case( -2); msg='Error in dintrv: x >= xt(lxt)'
+    case( -1_ip); msg='Error in dintrv: x < xt(1_ip)'
+    case( -2_ip); msg='Error in dintrv: x >= xt(lxt)'
 
-    case(  1); msg='Error in evaluate_*d: class is not initialized'
+    case(  1_ip); msg='Error in evaluate_*d: class is not initialized'
 
-    case(  2); msg='Error in db*ink: iknot out of range'
-    case(  3); msg='Error in db*ink: nx out of range'
-    case(  4); msg='Error in db*ink: kx out of range'
-    case(  5); msg='Error in db*ink: x not strictly increasing'
-    case(  6); msg='Error in db*ink: tx not non-decreasing'
-    case(  7); msg='Error in db*ink: ny out of range'
-    case(  8); msg='Error in db*ink: ky out of range'
-    case(  9); msg='Error in db*ink: y not strictly increasing'
-    case( 10); msg='Error in db*ink: ty not non-decreasing'
-    case( 11); msg='Error in db*ink: nz out of range'
-    case( 12); msg='Error in db*ink: kz out of range'
-    case( 13); msg='Error in db*ink: z not strictly increasing'
-    case( 14); msg='Error in db*ink: tz not non-decreasing'
-    case( 15); msg='Error in db*ink: nq out of range'
-    case( 16); msg='Error in db*ink: kq out of range'
-    case( 17); msg='Error in db*ink: q not strictly increasing'
-    case( 18); msg='Error in db*ink: tq not non-decreasing'
-    case( 19); msg='Error in db*ink: nr out of range'
-    case( 20); msg='Error in db*ink: kr out of range'
-    case( 21); msg='Error in db*ink: r not strictly increasing'
-    case( 22); msg='Error in db*ink: tr not non-decreasing'
-    case( 23); msg='Error in db*ink: ns out of range'
-    case( 24); msg='Error in db*ink: ks out of range'
-    case( 25); msg='Error in db*ink: s not strictly increasing'
-    case( 26); msg='Error in db*ink: ts not non-decreasing'
-    case(700); msg='Error in db*ink: size(x) /= size(fcn,1)'
-    case(701); msg='Error in db*ink: size(y) /= size(fcn,2)'
-    case(702); msg='Error in db*ink: size(z) /= size(fcn,3)'
-    case(703); msg='Error in db*ink: size(q) /= size(fcn,4)'
-    case(704); msg='Error in db*ink: size(r) /= size(fcn,5)'
-    case(705); msg='Error in db*ink: size(s) /= size(fcn,6)'
-    case(706); msg='Error in db*ink: size(x) /= nx'
-    case(707); msg='Error in db*ink: size(y) /= ny'
-    case(708); msg='Error in db*ink: size(z) /= nz'
-    case(709); msg='Error in db*ink: size(q) /= nq'
-    case(710); msg='Error in db*ink: size(r) /= nr'
-    case(711); msg='Error in db*ink: size(s) /= ns'
-    case(712); msg='Error in db*ink: size(tx) /= nx+kx'
-    case(713); msg='Error in db*ink: size(ty) /= ny+ky'
-    case(714); msg='Error in db*ink: size(tz) /= nz+kz'
-    case(715); msg='Error in db*ink: size(tq) /= nq+kq'
-    case(716); msg='Error in db*ink: size(tr) /= nr+kr'
-    case(717); msg='Error in db*ink: size(ts) /= ns+ks'
-    case(800); msg='Error in db*ink: size(x) /= size(bcoef,1)'
-    case(801); msg='Error in db*ink: size(y) /= size(bcoef,2)'
-    case(802); msg='Error in db*ink: size(z) /= size(bcoef,3)'
-    case(803); msg='Error in db*ink: size(q) /= size(bcoef,4)'
-    case(804); msg='Error in db*ink: size(r) /= size(bcoef,5)'
-    case(805); msg='Error in db*ink: size(s) /= size(bcoef,6)'
+    case(  2_ip); msg='Error in db*ink: iknot out of range'
+    case(  3_ip); msg='Error in db*ink: nx out of range'
+    case(  4_ip); msg='Error in db*ink: kx out of range'
+    case(  5_ip); msg='Error in db*ink: x not strictly increasing'
+    case(  6_ip); msg='Error in db*ink: tx not non-decreasing'
+    case(  7_ip); msg='Error in db*ink: ny out of range'
+    case(  8_ip); msg='Error in db*ink: ky out of range'
+    case(  9_ip); msg='Error in db*ink: y not strictly increasing'
+    case( 10_ip); msg='Error in db*ink: ty not non-decreasing'
+    case( 11_ip); msg='Error in db*ink: nz out of range'
+    case( 12_ip); msg='Error in db*ink: kz out of range'
+    case( 13_ip); msg='Error in db*ink: z not strictly increasing'
+    case( 14_ip); msg='Error in db*ink: tz not non-decreasing'
+    case( 15_ip); msg='Error in db*ink: nq out of range'
+    case( 16_ip); msg='Error in db*ink: kq out of range'
+    case( 17_ip); msg='Error in db*ink: q not strictly increasing'
+    case( 18_ip); msg='Error in db*ink: tq not non-decreasing'
+    case( 19_ip); msg='Error in db*ink: nr out of range'
+    case( 20_ip); msg='Error in db*ink: kr out of range'
+    case( 21_ip); msg='Error in db*ink: r not strictly increasing'
+    case( 22_ip); msg='Error in db*ink: tr not non-decreasing'
+    case( 23_ip); msg='Error in db*ink: ns out of range'
+    case( 24_ip); msg='Error in db*ink: ks out of range'
+    case( 25_ip); msg='Error in db*ink: s not strictly increasing'
+    case( 26_ip); msg='Error in db*ink: ts not non-decreasing'
+    case(700_ip); msg='Error in db*ink: size(x) /= size(fcn,1)'
+    case(701_ip); msg='Error in db*ink: size(y) /= size(fcn,2)'
+    case(702_ip); msg='Error in db*ink: size(z) /= size(fcn,3)'
+    case(703_ip); msg='Error in db*ink: size(q) /= size(fcn,4)'
+    case(704_ip); msg='Error in db*ink: size(r) /= size(fcn,5)'
+    case(705_ip); msg='Error in db*ink: size(s) /= size(fcn,6)'
+    case(706_ip); msg='Error in db*ink: size(x) /= nx'
+    case(707_ip); msg='Error in db*ink: size(y) /= ny'
+    case(708_ip); msg='Error in db*ink: size(z) /= nz'
+    case(709_ip); msg='Error in db*ink: size(q) /= nq'
+    case(710_ip); msg='Error in db*ink: size(r) /= nr'
+    case(711_ip); msg='Error in db*ink: size(s) /= ns'
+    case(712_ip); msg='Error in db*ink: size(tx) /= nx+kx'
+    case(713_ip); msg='Error in db*ink: size(ty) /= ny+ky'
+    case(714_ip); msg='Error in db*ink: size(tz) /= nz+kz'
+    case(715_ip); msg='Error in db*ink: size(tq) /= nq+kq'
+    case(716_ip); msg='Error in db*ink: size(tr) /= nr+kr'
+    case(717_ip); msg='Error in db*ink: size(ts) /= ns+ks'
+    case(800_ip); msg='Error in db*ink: size(x) /= size(bcoef,1)'
+    case(801_ip); msg='Error in db*ink: size(y) /= size(bcoef,2)'
+    case(802_ip); msg='Error in db*ink: size(z) /= size(bcoef,3)'
+    case(803_ip); msg='Error in db*ink: size(q) /= size(bcoef,4)'
+    case(804_ip); msg='Error in db*ink: size(r) /= size(bcoef,5)'
+    case(805_ip); msg='Error in db*ink: size(s) /= size(bcoef,6)'
 
-    case(100); msg='Error in dbintk: k does not satisfy k>=1'
-    case(101); msg='Error in dbintk: n does not satisfy n>=k'
-    case(102); msg='Error in dbintk: x(i) does not satisfy x(i)<x(i+1) for some i'
-    case(103); msg='Error in dbintk: some abscissa was not in the support of the '//&
-                    'corresponding basis function and the system is singular'
-    case(104); msg='Error in dbintk: the system of solver detects a singular system '//&
-                   'although the theoretical conditions for a solution were satisfied'
+    case(100_ip); msg='Error in dbintk: k does not satisfy k>=1'
+    case(101_ip); msg='Error in dbintk: n does not satisfy n>=k'
+    case(102_ip); msg='Error in dbintk: x(i) does not satisfy x(i)<x(i+1) for some i'
+    case(103_ip); msg='Error in dbintk: some abscissa was not in the support of the '//&
+                      'corresponding basis function and the system is singular'
+    case(104_ip); msg='Error in dbintk: the system of solver detects a singular system '//&
+                      'although the theoretical conditions for a solution were satisfied'
 
-    case(201); msg='Error in dbspvn: k does not satisfy k>=1'
-    case(202); msg='Error in dbspvn: jhigh does not satisfy 1<=jhigh<=k'
-    case(203); msg='Error in dbspvn: index is not 1 or 2'
-    case(204); msg='Error in dbspvn: x does not satisfy t(ileft)<=x<=t(ileft+1)'
+    case(201_ip); msg='Error in dbspvn: k does not satisfy k>=1'
+    case(202_ip); msg='Error in dbspvn: jhigh does not satisfy 1<=jhigh<=k'
+    case(203_ip); msg='Error in dbspvn: index is not 1 or 2'
+    case(204_ip); msg='Error in dbspvn: x does not satisfy t(ileft)<=x<=t(ileft+1)'
 
-    case(301); msg='Error in dbtpcf: n should be > 0'
+    case(301_ip); msg='Error in dbtpcf: n should be > 0'
 
-    case(401); msg='Error in dbvalu: k does not satisfy k>=1'
-    case(402); msg='Error in dbvalu: n does not satisfy n>=k'
-    case(403); msg='Error in dbvalu: ideriv does not satisfy 0<=ideriv<k'
-    case(404); msg='Error in dbvalu: x is not greater than or equal to t(k)'
-    case(405); msg='Error in dbvalu: x is not less than or equal to t(n+1)'
-    case(406); msg='Error in dbvalu: a left limiting value cannot be obtained at t(k)'
+    case(401_ip); msg='Error in dbvalu: k does not satisfy k>=1'
+    case(402_ip); msg='Error in dbvalu: n does not satisfy n>=k'
+    case(403_ip); msg='Error in dbvalu: ideriv does not satisfy 0<=ideriv<k'
+    case(404_ip); msg='Error in dbvalu: x is not greater than or equal to t(k)'
+    case(405_ip); msg='Error in dbvalu: x is not less than or equal to t(n+1)'
+    case(406_ip); msg='Error in dbvalu: a left limiting value cannot be obtained at t(k)'
 
-    case(501); msg='Error in initialize_*d_specify_knots: tx is not the correct size (kx+nx)'
-    case(502); msg='Error in initialize_*d_specify_knots: ty is not the correct size (ky+ny)'
-    case(503); msg='Error in initialize_*d_specify_knots: tz is not the correct size (kz+nz)'
-    case(504); msg='Error in initialize_*d_specify_knots: tq is not the correct size (kq+nq)'
-    case(505); msg='Error in initialize_*d_specify_knots: tr is not the correct size (kr+nr)'
-    case(506); msg='Error in initialize_*d_specify_knots: ts is not the correct size (ks+ns)'
+    case(501_ip); msg='Error in initialize_*d_specify_knots: tx is not the correct size (kx+nx)'
+    case(502_ip); msg='Error in initialize_*d_specify_knots: ty is not the correct size (ky+ny)'
+    case(503_ip); msg='Error in initialize_*d_specify_knots: tz is not the correct size (kz+nz)'
+    case(504_ip); msg='Error in initialize_*d_specify_knots: tq is not the correct size (kq+nq)'
+    case(505_ip); msg='Error in initialize_*d_specify_knots: tr is not the correct size (kr+nr)'
+    case(506_ip); msg='Error in initialize_*d_specify_knots: ts is not the correct size (ks+ns)'
 
-    case(601); msg='Error in db*val: x value out of bounds'
-    case(602); msg='Error in db*val: y value out of bounds'
-    case(603); msg='Error in db*val: z value out of bounds'
-    case(604); msg='Error in db*val: q value out of bounds'
-    case(605); msg='Error in db*val: r value out of bounds'
-    case(606); msg='Error in db*val: s value out of bounds'
+    case(601_ip); msg='Error in db*val: x value out of bounds'
+    case(602_ip); msg='Error in db*val: y value out of bounds'
+    case(603_ip); msg='Error in db*val: z value out of bounds'
+    case(604_ip); msg='Error in db*val: q value out of bounds'
+    case(605_ip); msg='Error in db*val: r value out of bounds'
+    case(606_ip); msg='Error in db*val: s value out of bounds'
 
-    case(901); msg='Error in dbsqad: k does not satisfy 1<=k<=20'
-    case(902); msg='Error in dbsqad: n does not satisfy n>=k'
-    case(903); msg='Error in dbsqad: x1 or x2 or both do not satisfy t(k)<=x<=t(n+1)'
+    case(901_ip); msg='Error in dbsqad: k does not satisfy 1<=k<=20'
+    case(902_ip); msg='Error in dbsqad: n does not satisfy n>=k'
+    case(903_ip); msg='Error in dbsqad: x1 or x2 or both do not satisfy t(k)<=x<=t(n+1)'
 
-    case(1001); msg='Error in dbfqad: k does not satisfy k>=1'
-    case(1002); msg='Error in dbfqad: n does not satisfy n>=k'
-    case(1003); msg='Error in dbfqad: d does not satisfy 0<=id<k'
-    case(1004); msg='Error in dbfqad: x1 or x2 or both do not satisfy t(k)<=x<=t(n+1)'
-    case(1005); msg='Error in dbfqad: tol is less than dtol or greater than 0.1'
+    case(1001_ip); msg='Error in dbfqad: k does not satisfy k>=1'
+    case(1002_ip); msg='Error in dbfqad: n does not satisfy n>=k'
+    case(1003_ip); msg='Error in dbfqad: d does not satisfy 0<=id<k'
+    case(1004_ip); msg='Error in dbfqad: x1 or x2 or both do not satisfy t(k)<=x<=t(n+1)'
+    case(1005_ip); msg='Error in dbfqad: tol is less than dtol or greater than 0.1'
 
-    case(1101); msg='Warning in dbsgq8: a and b are too nearly equal to allow normal integration.'
-    case(1102); msg='Error in dbsgq8: ans is probably insufficiently accurate.'
+    case(1101_ip); msg='Warning in dbsgq8: a and b are too nearly equal to allow normal integration.'
+    case(1102_ip); msg='Error in dbsgq8: ans is probably insufficiently accurate.'
 
     case default
         write(istr,fmt='(I10)',iostat=istat) iflag

--- a/src/bspline_sub_module.f90
+++ b/src/bspline_sub_module.f90
@@ -169,11 +169,11 @@
 !
 !  [[db1val]] returns 0.0 if (`xval`,`yval`) is out of range. that is, if
 !```fortran
-!   xval < tx(1_ip) .or. xval > tx(nx+kx)
+!   xval < tx(1) .or. xval > tx(nx+kx)
 !```
 !  if the knots `tx` were chosen by [[db1ink]], then this is equivalent to:
 !```fortran
-!   xval < x(1_ip) .or. xval > x(nx)+epsx
+!   xval < x(1) .or. xval > x(nx)+epsx
 !```
 !  where
 !```fortran
@@ -258,7 +258,7 @@
 !  function `fun` and the `idx`-th derivative of a `kx`-th order b-spline,
 !  using the b-representation `(tx,bcoef,nx,kx)`, with an adaptive
 !  8-point Legendre-Gauss algorithm.
-!  `(x1,x2)` must be a subinterval of `t(kx) <= x <= t(nx+1_ip)`.
+!  `(x1,x2)` must be a subinterval of `t(kx) <= x <= t(nx+1)`.
 !
 !### See also
 !  * [[dbfqad]] -- the core routine.
@@ -300,7 +300,7 @@
 !>
 !  Determines the parameters of a function that interpolates
 !  the two-dimensional gridded data
-!  $$ [x(i),y(j),\mathrm{fcn}(i,j)] ~\mathrm{for}~ i=1_ip,..,n_x ~\mathrm{and}~ j=1_ip,..,n_y $$
+!  $$ [x(i),y(j),\mathrm{fcn}(i,j)] ~\mathrm{for}~ i=1,..,n_x ~\mathrm{and}~ j=1,..,n_y $$
 !  The interpolating function and its derivatives may
 !  subsequently be evaluated by the function [[db2val]].
 !
@@ -313,7 +313,7 @@
 !  where the functions \(u_i\) and \(v_j\) are one-dimensional b-spline
 !  basis functions. the coefficients \( a_{ij} \) are chosen so that
 !
-!  $$ s(x(i),y(j)) = \mathrm{fcn}(i,j) ~\mathrm{for}~ i=1_ip,..,n_x ~\mathrm{and}~ j=1_ip,..,n_y $$
+!  $$ s(x(i),y(j)) = \mathrm{fcn}(i,j) ~\mathrm{for}~ i=1,..,n_x ~\mathrm{and}~ j=1,..,n_y $$
 !
 !  Note that for each fixed value of \(y\), \( s(x,y) \) is a piecewise
 !  polynomial function of \(x\) alone, and for each fixed value of \(x\), \( s(x,y) \)
@@ -403,7 +403,7 @@
 
     logical :: status_ok
     real(wp),dimension(:),allocatable :: temp !! work array of length `nx*ny`
-    real(wp),dimension(:),allocatable :: work !! work array of length `max(2_ip*kx*(nx+1_ip),2_ip*ky*(ny+1_ip))`
+    real(wp),dimension(:),allocatable :: work !! work array of length `max(2*kx*(nx+1),2*ky*(ny+1))`
 
     !check validity of inputs
 
@@ -448,17 +448,17 @@
 !
 !  To evaluate the interpolant
 !  itself, set `idx=idy=0`, to evaluate the first partial with respect
-!  to `x`, set `idx=1_ip,idy=0`, and so on.
+!  to `x`, set `idx=1,idy=0`, and so on.
 !
 !  [[db2val]] returns 0.0 if `(xval,yval)` is out of range. that is, if
 !```fortran
-!   xval < tx(1_ip) .or. xval > tx(nx+kx) .or.
-!   yval < ty(1_ip) .or. yval > ty(ny+ky)
+!   xval < tx(1) .or. xval > tx(nx+kx) .or.
+!   yval < ty(1) .or. yval > ty(ny+ky)
 !```
 !  if the knots tx and ty were chosen by [[db2ink]], then this is equivalent to:
 !```fortran
-!   xval < x(1_ip) .or. xval > x(nx)+epsx .or.
-!   yval < y(1_ip) .or. yval > y(ny)+epsy
+!   xval < x(1) .or. xval > x(nx)+epsx .or.
+!   yval < y(1) .or. yval > y(ny)+epsy
 !```
 !  where
 !```fortran
@@ -861,8 +861,8 @@
 !  Determines the parameters of a function that interpolates
 !  the four-dimensional gridded data
 !  $$ [x(i),y(j),z(k),q(l),\mathrm{fcn}(i,j,k,l)] ~\mathrm{for}~
-!     i=1_ip,..,n_x ~\mathrm{and}~ j=1_ip,..,n_y, ~\mathrm{and}~ k=1_ip,..,n_z,
-!     ~\mathrm{and}~ l=1_ip,..,n_q $$
+!     i=1,..,n_x ~\mathrm{and}~ j=1,..,n_y, ~\mathrm{and}~ k=1,..,n_z,
+!     ~\mathrm{and}~ l=1,..,n_q $$
 !  The interpolating function and its derivatives may
 !  subsequently be evaluated by the function [[db4val]].
 !
@@ -974,8 +974,8 @@
 
     logical :: status_ok
     real(wp),dimension(:),allocatable :: temp !! work array of dimension `nx*ny*nz*nq`
-    real(wp),dimension(:),allocatable :: work !! work array of dimension `max(2_ip*kx*(nx+1_ip),
-                                              !! 2_ip*ky*(ny+1_ip),2_ip*kz*(nz+1_ip),2_ip*kq*(nq+1_ip))`
+    real(wp),dimension(:),allocatable :: work !! work array of dimension `max(2*kx*(nx+1),
+                                              !! 2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1))`
 
     ! check validity of input
 
@@ -1003,7 +1003,7 @@
         allocate(work(max(2_ip*kx*(nx+1_ip),2_ip*ky*(ny+1_ip),2_ip*kz*(nz+1_ip),2_ip*kq*(nq+1_ip))))
 
         ! construct b-spline coefficients
-                      call dbtpcf(x,nx,fcn,  nx,ny*nz*nq,tx,kx,temp, work,iflag)
+                         call dbtpcf(x,nx,fcn,  nx,ny*nz*nq,tx,kx,temp, work,iflag)
         if (iflag==0_ip) call dbtpcf(y,ny,temp, ny,nx*nz*nq,ty,ky,bcoef,work,iflag)
         if (iflag==0_ip) call dbtpcf(z,nz,bcoef,nz,nx*ny*nq,tz,kz,temp, work,iflag)
         if (iflag==0_ip) call dbtpcf(q,nq,temp, nq,nx*ny*nz,tq,kq,bcoef,work,iflag)
@@ -1317,7 +1317,7 @@
     logical :: status_ok
     real(wp),dimension(:),allocatable :: temp !! work array of length `nx*ny*nz*nq*nr`
     real(wp),dimension(:),allocatable :: work !! work array of length `max(2*kx*(nx+1),
-                                              !! 2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1),2_ip*kr*(nr+1))`
+                                              !! 2*ky*(ny+1),2*kz*(nz+1),2*kq*(nq+1),2*kr*(nr+1))`
     integer(ip) :: i, j, k, l, m, ii !! counter
 
     !  check validity of input
@@ -1364,7 +1364,7 @@
         end do
 
         !  construct b-spline coefficients
-                      call dbtpcf(x,nx,temp,  nx,ny*nz*nq*nr,tx,kx,bcoef,work,iflag)
+                         call dbtpcf(x,nx,temp,  nx,ny*nz*nq*nr,tx,kx,bcoef,work,iflag)
         if (iflag==0_ip) call dbtpcf(y,ny,bcoef, ny,nx*nz*nq*nr,ty,ky,temp, work,iflag)
         if (iflag==0_ip) call dbtpcf(z,nz,temp,  nz,nx*ny*nq*nr,tz,kz,bcoef,work,iflag)
         if (iflag==0_ip) call dbtpcf(q,nq,bcoef, nq,nx*ny*nz*nr,tq,kq,temp, work,iflag)

--- a/src/tests/bspline_extrap_test.f90
+++ b/src/tests/bspline_extrap_test.f90
@@ -8,23 +8,23 @@
     program bspline_extrap_test
 
     use bspline_module
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
     use pyplot_module
 
     implicit none
 
-    integer,parameter :: nx    = 400   !! number of points in x
-    integer,parameter :: nxv   = 800   !! number of points to evaluate interpolant
+    integer(ip),parameter :: nx    = 400   !! number of points in x
+    integer(ip),parameter :: nxv   = 800   !! number of points to evaluate interpolant
 
-    integer,parameter :: kx    = 4    !! order in x
-    integer,parameter :: iknot = 0    !! automatically select the knots
+    integer(ip),parameter :: kx    = 4    !! order in x
+    integer(ip),parameter :: iknot = 0    !! automatically select the knots
 
     real(wp) :: x(nx)
     real(wp) :: xval(nxv),fval(nxv)
     real(wp) :: tx(nx+kx)
     real(wp) :: fcn_1d(nx)
     real(wp) :: val,tru,err,errmax
-    integer  :: i,j,idx,iflag,inbvx,iloy
+    integer(ip) :: i,j,idx,iflag,inbvx,iloy
     logical :: extrap
     type(pyplot) :: plt
     integer :: istat  !! pyplot-fortran status flag

--- a/src/tests/bspline_extrap_test.f90
+++ b/src/tests/bspline_extrap_test.f90
@@ -28,6 +28,7 @@
     logical :: extrap
     type(pyplot) :: plt
     integer :: istat  !! pyplot-fortran status flag
+    real(wp),dimension(3*kx) :: w1_1d !! work array
 
     real(wp),parameter :: rad2deg = 180.0_wp / acos(-1.0_wp)  !! deg. to radians conversion factor
 
@@ -65,7 +66,7 @@
 
         errmax = 0.0_wp
         do i=1,nxv
-            call db1val(xval(i),idx,tx,nx,kx,fcn_1d,val,iflag,inbvx,extrap=extrap)
+            call db1val(xval(i),idx,tx,nx,kx,fcn_1d,val,iflag,inbvx,w1_1d,extrap=extrap)
             fval(i) = val  ! save it for plot
             tru    = f1(xval(i))
             err    = abs(tru-val)

--- a/src/tests/bspline_test.f90
+++ b/src/tests/bspline_test.f90
@@ -34,6 +34,28 @@
     real(wp) :: fcn_5d(nx,ny,nz,nq,nr)
     real(wp) :: fcn_6d(nx,ny,nz,nq,nr,ns)
 
+    real(wp),dimension(3*kx)                     :: w1_1d
+    real(wp),dimension(ky)                       :: w1_2d
+    real(wp),dimension(3*max(kx,ky))             :: w2_2d
+    real(wp),dimension(ky,kz)                    :: w1_3d
+    real(wp),dimension(kz)                       :: w2_3d
+    real(wp),dimension(3*max(kx,ky,kz))          :: w3_3d
+    real(wp),dimension(ky,kz,kq)                 :: w1_4d
+    real(wp),dimension(kz,kq)                    :: w2_4d
+    real(wp),dimension(kq)                       :: w3_4d
+    real(wp),dimension(3*max(kx,ky,kz,kq))       :: w4_4d
+    real(wp),dimension(ky,kz,kq,kr)              :: w1_5d
+    real(wp),dimension(kz,kq,kr)                 :: w2_5d
+    real(wp),dimension(kq,kr)                    :: w3_5d
+    real(wp),dimension(kr)                       :: w4_5d
+    real(wp),dimension(3*max(kx,ky,kz,kq,kr))    :: w5_5d
+    real(wp),dimension(ky,kz,kq,kr,ks)           :: w1_6d
+    real(wp),dimension(kz,kq,kr,ks)              :: w2_6d
+    real(wp),dimension(kq,kr,ks)                 :: w3_6d
+    real(wp),dimension(kr,ks)                    :: w4_6d
+    real(wp),dimension(ks)                       :: w5_6d
+    real(wp),dimension(3*max(kx,ky,kz,kq,kr,ks)) :: w6_6d
+
     real(wp) :: tol
     real(wp),dimension(6) :: val,tru,err,errmax
     logical :: fail
@@ -122,42 +144,48 @@
      errmax = 0.0_wp
      do i=1,nx
                         call db1val(x(i),idx,&
-                                            tx,nx,kx,fcn_1d,val(1),iflag(1),inbvx)
+                                            tx,nx,kx,fcn_1d,val(1),iflag(1),inbvx,&
+                                            w1_1d)
                         tru(1)    = f1(x(i))
                         err(1)    = abs(tru(1)-val(1))
                         errmax(1) = max(err(1),errmax(1))
         do j=1,ny
                         call db2val(x(i),y(j),idx,idy,&
                                             tx,ty,nx,ny,kx,ky,fcn_2d,val(2),iflag(2),&
-                                            inbvx,inbvy,iloy)
+                                            inbvx,inbvy,iloy,&
+                                            w1_2d,w2_2d)
                         tru(2)    = f2(x(i),y(j))
                         err(2)    = abs(tru(2)-val(2))
                         errmax(2) = max(err(2),errmax(2))
            do k=1,nz
                         call db3val(x(i),y(j),z(k),idx,idy,idz,&
                                             tx,ty,tz,nx,ny,nz,kx,ky,kz,fcn_3d,val(3),iflag(3),&
-                                            inbvx,inbvy,inbvz,iloy,iloz)
+                                            inbvx,inbvy,inbvz,iloy,iloz,&
+                                            w1_3d,w2_3d,w3_3d)
                         tru(3)    = f3(x(i),y(j),z(k))
                         err(3)    = abs(tru(3)-val(3))
                         errmax(3) = max(err(3),errmax(3))
               do l=1,nq
                         call db4val(x(i),y(j),z(k),q(l),idx,idy,idz,idq,&
                                             tx,ty,tz,tq,nx,ny,nz,nq,kx,ky,kz,kq,fcn_4d,val(4),iflag(4),&
-                                            inbvx,inbvy,inbvz,inbvq,iloy,iloz,iloq)
+                                            inbvx,inbvy,inbvz,inbvq,iloy,iloz,iloq,&
+                                            w1_4d,w2_4d,w3_4d,w4_4d)
                         tru(4)    = f4(x(i),y(j),z(k),q(l))
                         err(4)    = abs(tru(4)-val(4))
                         errmax(4) = max(err(4),errmax(4))
                 do m=1,nr
                         call db5val(x(i),y(j),z(k),q(l),r(m),idx,idy,idz,idq,idr,&
                                             tx,ty,tz,tq,tr,nx,ny,nz,nq,nr,kx,ky,kz,kq,kr,fcn_5d,val(5),iflag(5),&
-                                            inbvx,inbvy,inbvz,inbvq,inbvr,iloy,iloz,iloq,ilor)
+                                            inbvx,inbvy,inbvz,inbvq,inbvr,iloy,iloz,iloq,ilor,&
+                                            w1_5d,w2_5d,w3_5d,w4_5d,w5_5d)
                         tru(5)    = f5(x(i),y(j),z(k),q(l),r(m))
                         err(5)    = abs(tru(5)-val(5))
                         errmax(5) = max(err(5),errmax(5))
                     do n=1,ns
                         call db6val(x(i),y(j),z(k),q(l),r(m),s(n),idx,idy,idz,idq,idr,ids,&
                                             tx,ty,tz,tq,tr,ts,nx,ny,nz,nq,nr,ns,kx,ky,kz,kq,kr,ks,fcn_6d,val(6),iflag(6),&
-                                            inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos)
+                                            inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos,&
+                                            w1_6d,w2_6d,w3_6d,w4_6d,w5_6d,w6_6d)
                         tru(6)    = f6(x(i),y(j),z(k),q(l),r(m),s(n))
                         err(6)    = abs(tru(6)-val(6))
                         errmax(6) = max(err(6),errmax(6))

--- a/src/tests/bspline_test.f90
+++ b/src/tests/bspline_test.f90
@@ -5,25 +5,25 @@
     program bspline_test
 
     use bspline_module
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
 
     implicit none
 
-    integer,parameter :: nx = 6     !! number of points in x
-    integer,parameter :: ny = 6     !! number of points in y
-    integer,parameter :: nz = 6     !! number of points in z
-    integer,parameter :: nq = 6     !! number of points in q
-    integer,parameter :: nr = 6     !! number of points in r
-    integer,parameter :: ns = 6     !! number of points in s
+    integer(ip),parameter :: nx = 6     !! number of points in x
+    integer(ip),parameter :: ny = 6     !! number of points in y
+    integer(ip),parameter :: nz = 6     !! number of points in z
+    integer(ip),parameter :: nq = 6     !! number of points in q
+    integer(ip),parameter :: nr = 6     !! number of points in r
+    integer(ip),parameter :: ns = 6     !! number of points in s
 
-    integer,parameter :: kx = 4     !! order in x
-    integer,parameter :: ky = 4     !! order in y
-    integer,parameter :: kz = 4     !! order in z
-    integer,parameter :: kq = 4     !! order in q
-    integer,parameter :: kr = 4     !! order in r
-    integer,parameter :: ks = 4     !! order in s
+    integer(ip),parameter :: kx = 4     !! order in x
+    integer(ip),parameter :: ky = 4     !! order in y
+    integer(ip),parameter :: kz = 4     !! order in z
+    integer(ip),parameter :: kq = 4     !! order in q
+    integer(ip),parameter :: kr = 4     !! order in r
+    integer(ip),parameter :: ks = 4     !! order in s
 
-    integer,parameter :: iknot = 0  !! automatically select the knots
+    integer(ip),parameter :: iknot = 0  !! automatically select the knots
 
     real(wp) :: x(nx),y(ny),z(nz),q(nq),r(nr),s(ns)
     real(wp) :: tx(nx+kx),ty(ny+ky),tz(nz+kz),tq(nq+kq),tr(nr+kr),ts(ns+ks)
@@ -59,10 +59,10 @@
     real(wp) :: tol
     real(wp),dimension(6) :: val,tru,err,errmax
     logical :: fail
-    integer :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids
-    integer,dimension(6) :: iflag
-    integer :: inbvx,inbvy,inbvz,inbvq,inbvr,inbvs
-    integer :: iloy,iloz,iloq,ilor,ilos
+    integer(ip) :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids
+    integer(ip),dimension(6) :: iflag
+    integer(ip) :: inbvx,inbvy,inbvz,inbvq,inbvr,inbvs
+    integer(ip) :: iloy,iloz,iloq,ilor,ilos
 
     fail = .false.
     tol = 1.0e-14_wp
@@ -74,22 +74,22 @@
     ids = 0
 
      do i=1,nx
-        x(i) = dble(i-1)/dble(nx-1)
+        x(i) = real(i-1,wp)/real(nx-1,wp)
      end do
      do j=1,ny
-        y(j) = dble(j-1)/dble(ny-1)
+        y(j) = real(j-1,wp)/real(ny-1,wp)
      end do
      do k=1,nz
-        z(k) = dble(k-1)/dble(nz-1)
+        z(k) = real(k-1,wp)/real(nz-1,wp)
      end do
      do l=1,nq
-        q(l) = dble(l-1)/dble(nq-1)
+        q(l) = real(l-1,wp)/real(nq-1,wp)
      end do
      do m=1,nr
-        r(m) = dble(m-1)/dble(nr-1)
+        r(m) = real(m-1,wp)/real(nr-1,wp)
      end do
      do n=1,ns
-        s(n) = dble(n-1)/dble(ns-1)
+        s(n) = real(n-1,wp)/real(ns-1,wp)
      end do
      do i=1,nx
                         fcn_1d(i) = f1(x(i))

--- a/src/tests/bspline_test_2.f90
+++ b/src/tests/bspline_test_2.f90
@@ -5,25 +5,25 @@
     program bspline_test_2
 
     use bspline_module
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
 
     implicit none
 
-    integer,parameter :: nx = 6     !! number of points in x
-    integer,parameter :: ny = 6     !! number of points in y
-    integer,parameter :: nz = 6     !! number of points in z
-    integer,parameter :: nq = 6     !! number of points in q
-    integer,parameter :: nr = 6     !! number of points in r
-    integer,parameter :: ns = 6     !! number of points in s
+    integer(ip),parameter :: nx = 6     !! number of points in x
+    integer(ip),parameter :: ny = 6     !! number of points in y
+    integer(ip),parameter :: nz = 6     !! number of points in z
+    integer(ip),parameter :: nq = 6     !! number of points in q
+    integer(ip),parameter :: nr = 6     !! number of points in r
+    integer(ip),parameter :: ns = 6     !! number of points in s
 
-    integer,parameter :: kx = 4     !! order in x
-    integer,parameter :: ky = 4     !! order in y
-    integer,parameter :: kz = 4     !! order in z
-    integer,parameter :: kq = 4     !! order in q
-    integer,parameter :: kr = 4     !! order in r
-    integer,parameter :: ks = 4     !! order in s
+    integer(ip),parameter :: kx = 4     !! order in x
+    integer(ip),parameter :: ky = 4     !! order in y
+    integer(ip),parameter :: kz = 4     !! order in z
+    integer(ip),parameter :: kq = 4     !! order in q
+    integer(ip),parameter :: kr = 4     !! order in r
+    integer(ip),parameter :: ks = 4     !! order in s
 
-    integer,parameter :: iknot = 0  !! automatically select the knots
+    integer(ip),parameter :: iknot = 0  !! automatically select the knots
 
     real(wp),parameter :: tol = 1.0e-2_wp !! tolerance for interp/extrap failure
 
@@ -61,10 +61,10 @@
 
     real(wp),dimension(6) :: val,tru,err,errmax
     logical :: fail
-    integer :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids
-    integer,dimension(6) :: iflag
-    integer :: inbvx,inbvy,inbvz,inbvq,inbvr,inbvs
-    integer :: iloy,iloz,iloq,ilor,ilos
+    integer(ip) :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids
+    integer(ip),dimension(6) :: iflag
+    integer(ip) :: inbvx,inbvy,inbvz,inbvq,inbvr,inbvs
+    integer(ip) :: iloy,iloz,iloq,ilor,ilos
 
     fail = .false.
     idx = 0
@@ -75,22 +75,22 @@
     ids = 0
 
      do i=1,nx
-        x(i) = dble(i-1)/dble(nx-1)
+        x(i) = real(i-1,wp)/real(nx-1,wp)
      end do
      do j=1,ny
-        y(j) = dble(j-1)/dble(ny-1)
+        y(j) = real(j-1,wp)/real(ny-1,wp)
      end do
      do k=1,nz
-        z(k) = dble(k-1)/dble(nz-1)
+        z(k) = real(k-1,wp)/real(nz-1,wp)
      end do
      do l=1,nq
-        q(l) = dble(l-1)/dble(nq-1)
+        q(l) = real(l-1,wp)/real(nq-1,wp)
      end do
      do m=1,nr
-        r(m) = dble(m-1)/dble(nr-1)
+        r(m) = real(m-1,wp)/real(nr-1,wp)
      end do
      do n=1,ns
-        s(n) = dble(n-1)/dble(ns-1)
+        s(n) = real(n-1,wp)/real(ns-1,wp)
      end do
      do i=1,nx
                         fcn_1d(i) = f1(x(i))
@@ -113,22 +113,22 @@
 
      ! points to evaluate:
      do i=0,nx+1
-        xval(i+1) = dble(i-1)/dble(nx-1)
+        xval(i+1) = real(i-1,wp)/real(nx-1,wp)
      end do
      do j=0,ny+1
-        yval(j+1) = dble(j-1)/dble(ny-1)
+        yval(j+1) = real(j-1,wp)/real(ny-1,wp)
      end do
      do k=0,nz+1
-        zval(k+1) = dble(k-1)/dble(nz-1)
+        zval(k+1) = real(k-1,wp)/real(nz-1,wp)
      end do
      do l=0,nq+1
-        qval(l+1) = dble(l-1)/dble(nq-1)
+        qval(l+1) = real(l-1,wp)/real(nq-1,wp)
      end do
      do m=0,nr+1
-        rval(m+1) = dble(m-1)/dble(nr-1)
+        rval(m+1) = real(m-1,wp)/real(nr-1,wp)
      end do
      do n=0,ns+1
-        sval(n+1) = dble(n-1)/dble(ns-1)
+        sval(n+1) = real(n-1,wp)/real(ns-1,wp)
      end do
 
     !have to set these before the first evaluate call:

--- a/src/tests/bspline_test_2.f90
+++ b/src/tests/bspline_test_2.f90
@@ -37,6 +37,28 @@
     real(wp) :: fcn_5d(nx,ny,nz,nq,nr)
     real(wp) :: fcn_6d(nx,ny,nz,nq,nr,ns)
 
+    real(wp),dimension(3*kx)                     :: w1_1d
+    real(wp),dimension(ky)                       :: w1_2d
+    real(wp),dimension(3*max(kx,ky))             :: w2_2d
+    real(wp),dimension(ky,kz)                    :: w1_3d
+    real(wp),dimension(kz)                       :: w2_3d
+    real(wp),dimension(3*max(kx,ky,kz))          :: w3_3d
+    real(wp),dimension(ky,kz,kq)                 :: w1_4d
+    real(wp),dimension(kz,kq)                    :: w2_4d
+    real(wp),dimension(kq)                       :: w3_4d
+    real(wp),dimension(3*max(kx,ky,kz,kq))       :: w4_4d
+    real(wp),dimension(ky,kz,kq,kr)              :: w1_5d
+    real(wp),dimension(kz,kq,kr)                 :: w2_5d
+    real(wp),dimension(kq,kr)                    :: w3_5d
+    real(wp),dimension(kr)                       :: w4_5d
+    real(wp),dimension(3*max(kx,ky,kz,kq,kr))    :: w5_5d
+    real(wp),dimension(ky,kz,kq,kr,ks)           :: w1_6d
+    real(wp),dimension(kz,kq,kr,ks)              :: w2_6d
+    real(wp),dimension(kq,kr,ks)                 :: w3_6d
+    real(wp),dimension(kr,ks)                    :: w4_6d
+    real(wp),dimension(ks)                       :: w5_6d
+    real(wp),dimension(3*max(kx,ky,kz,kq,kr,ks)) :: w6_6d
+
     real(wp),dimension(6) :: val,tru,err,errmax
     logical :: fail
     integer :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids
@@ -146,7 +168,7 @@
      err = -99999.9_wp
      do i=1,nx+2
                         call db1val(xval(i),idx,&
-                                            tx,nx,kx,fcn_1d,val(1),iflag(1),inbvx,extrap=.true.)
+                                            tx,nx,kx,fcn_1d,val(1),iflag(1),inbvx,w1_1d,extrap=.true.)
                         tru(1)    = f1(xval(i))
                         err(1)    = abs(tru(1)-val(1))
                         errmax(1) = max(err(1),errmax(1))
@@ -154,7 +176,7 @@
         do j=1,ny+2
                         call db2val(xval(i),yval(j),idx,idy,&
                                             tx,ty,nx,ny,kx,ky,fcn_2d,val(2),iflag(2),&
-                                            inbvx,inbvy,iloy,extrap=.true.)
+                                            inbvx,inbvy,iloy,w1_2d,w2_2d,extrap=.true.)
                         tru(2)    = f2(xval(i),yval(j))
                         err(2)    = abs(tru(2)-val(2))
                         errmax(2) = max(err(2),errmax(2))
@@ -162,7 +184,7 @@
            do k=1,nz+2
                         call db3val(xval(i),yval(j),zval(k),idx,idy,idz,&
                                             tx,ty,tz,nx,ny,nz,kx,ky,kz,fcn_3d,val(3),iflag(3),&
-                                            inbvx,inbvy,inbvz,iloy,iloz,extrap=.true.)
+                                            inbvx,inbvy,inbvz,iloy,iloz,w1_3d,w2_3d,w3_3d,extrap=.true.)
                         tru(3)    = f3(xval(i),yval(j),zval(k))
                         err(3)    = abs(tru(3)-val(3))
                         errmax(3) = max(err(3),errmax(3))
@@ -170,7 +192,8 @@
               do l=1,nq+2
                         call db4val(xval(i),yval(j),zval(k),qval(l),idx,idy,idz,idq,&
                                             tx,ty,tz,tq,nx,ny,nz,nq,kx,ky,kz,kq,fcn_4d,val(4),iflag(4),&
-                                            inbvx,inbvy,inbvz,inbvq,iloy,iloz,iloq,extrap=.true.)
+                                            inbvx,inbvy,inbvz,inbvq,iloy,iloz,iloq,&
+                                            w1_4d,w2_4d,w3_4d,w4_4d,extrap=.true.)
                         tru(4)    = f4(xval(i),yval(j),zval(k),qval(l))
                         err(4)    = abs(tru(4)-val(4))
                         errmax(4) = max(err(4),errmax(4))
@@ -178,7 +201,8 @@
                 do m=1,nr+2
                         call db5val(xval(i),yval(j),zval(k),qval(l),rval(m),idx,idy,idz,idq,idr,&
                                             tx,ty,tz,tq,tr,nx,ny,nz,nq,nr,kx,ky,kz,kq,kr,fcn_5d,val(5),iflag(5),&
-                                            inbvx,inbvy,inbvz,inbvq,inbvr,iloy,iloz,iloq,ilor,extrap=.true.)
+                                            inbvx,inbvy,inbvz,inbvq,inbvr,iloy,iloz,iloq,ilor,&
+                                            w1_5d,w2_5d,w3_5d,w4_5d,w5_5d,extrap=.true.)
                         tru(5)    = f5(xval(i),yval(j),zval(k),qval(l),rval(m))
                         err(5)    = abs(tru(5)-val(5))
                         errmax(5) = max(err(5),errmax(5))
@@ -186,7 +210,8 @@
                     do n=1,ns+2
                         call db6val(xval(i),yval(j),zval(k),qval(l),rval(m),sval(n),idx,idy,idz,idq,idr,ids,&
                                             tx,ty,tz,tq,tr,ts,nx,ny,nz,nq,nr,ns,kx,ky,kz,kq,kr,ks,fcn_6d,val(6),iflag(6),&
-                                            inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos,extrap=.true.)
+                                            inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos,&
+                                            w1_6d,w2_6d,w3_6d,w4_6d,w5_6d,w6_6d,extrap=.true.)
                         tru(6)    = f6(xval(i),yval(j),zval(k),qval(l),rval(m),sval(n))
                         err(6)    = abs(tru(6)-val(6))
                         errmax(6) = max(err(6),errmax(6))

--- a/src/tests/knot_tests.f90
+++ b/src/tests/knot_tests.f90
@@ -12,15 +12,15 @@
     program knot_tests
 
     use bspline_module
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
     use pyplot_module
 
     implicit none
 
     integer :: i    !! counter
 
-    integer,parameter :: kx  = 4    !! x bspline order
-    integer,parameter :: nx  = 6    !! number of points in x dimension
+    integer(ip),parameter :: kx  = 4    !! x bspline order
+    integer(ip),parameter :: nx  = 6    !! number of points in x dimension
     real(wp),dimension(nx),parameter :: x = [(real(i*10,wp), i=0,11,(10+2)/nx)]    !! [0,20,40,60,80,100]
 
     real(wp),dimension(nx)    :: fcn
@@ -29,7 +29,7 @@
     real(wp),dimension(0:100) :: x_new,f_new_default,f1,f2 !,f_actual
     real(wp)                  :: xval
     type(pyplot)              :: plt
-    integer                   :: iflag
+    integer(ip)               :: iflag
     integer                   :: istat  !! pyplot-fortran status flag
 
     !function evaluations for original grid:
@@ -68,13 +68,13 @@
 
         !f_actual(i) = test_func(xval)
 
-        call s_default%evaluate(xval,0,f_new_default(i),iflag)
+        call s_default%evaluate(xval,0_ip,f_new_default(i),iflag)
         if (iflag/=0) error stop 'error evaluating s_default'
 
-        call s1%evaluate(xval,0,f1(i),iflag)
+        call s1%evaluate(xval,0_ip,f1(i),iflag)
         if (iflag/=0) error stop 'error evaluating s1'
 
-        call s2%evaluate(xval,0,f2(i),iflag)
+        call s2%evaluate(xval,0_ip,f2(i),iflag)
         if (iflag/=0) error stop 'error evaluating s2'
 
     end do

--- a/src/tests/speed_test.f90
+++ b/src/tests/speed_test.f90
@@ -8,26 +8,26 @@
     program bspline_speed_test
 
     use bspline_module
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
     use pyplot_module
 
     implicit none
 
-    integer,parameter :: nx = 8   !number of points
-    integer,parameter :: ny = 8
-    integer,parameter :: nz = 8
-    integer,parameter :: nq = 8
-    integer,parameter :: nr = 8
-    integer,parameter :: ns = 8
+    integer(ip),parameter :: nx = 8   !number of points
+    integer(ip),parameter :: ny = 8
+    integer(ip),parameter :: nz = 8
+    integer(ip),parameter :: nq = 8
+    integer(ip),parameter :: nr = 8
+    integer(ip),parameter :: ns = 8
 
-    integer,parameter :: kx = 4    !order
-    integer,parameter :: ky = 4
-    integer,parameter :: kz = 4
-    integer,parameter :: kq = 4
-    integer,parameter :: kr = 4
-    integer,parameter :: ks = 4
+    integer(ip),parameter :: kx = 4    !order
+    integer(ip),parameter :: ky = 4
+    integer(ip),parameter :: kz = 4
+    integer(ip),parameter :: kq = 4
+    integer(ip),parameter :: kr = 4
+    integer(ip),parameter :: ks = 4
 
-    integer,parameter :: n_cases = nx*ny*nz*nq*nr*ns
+    integer(ip),parameter :: n_cases = nx*ny*nz*nq*nr*ns
 
     real(wp) :: x(nx),y(ny),z(nz),q(nq),r(nr),s(ns)
     real(wp),dimension(nx) :: fcn_1d, bcoef_1d
@@ -61,11 +61,11 @@
     real(wp),dimension(3*max(kx,ky,kz,kq,kr,ks)) :: w6_6d
 
     real(wp) :: val,sumval
-    integer  :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids,iknot,iflag
+    integer(ip)  :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids,iknot,iflag
     real :: tstart, tend
     type(pyplot) :: plt
     real(wp),dimension(6) :: cases_per_sec
-    integer :: inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos
+    integer(ip) :: inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos
     integer :: istat  !! pyplot-fortran status flag
 
     inbvx = 1
@@ -87,12 +87,12 @@
     idr = 0
     ids = 0
 
-    x = [ (dble(i), i=1,nx) ]
-    y = [ (dble(i), i=1,ny) ]
-    z = [ (dble(i), i=1,nz) ]
-    q = [ (dble(i), i=1,nq) ]
-    r = [ (dble(i), i=1,nr) ]
-    s = [ (dble(i), i=1,ns) ]
+    x = [ (real(i,wp), i=1,nx) ]
+    y = [ (real(i,wp), i=1,ny) ]
+    z = [ (real(i,wp), i=1,nz) ]
+    q = [ (real(i,wp), i=1,nq) ]
+    r = [ (real(i,wp), i=1,nr) ]
+    s = [ (real(i,wp), i=1,ns) ]
 
     !evaluate the functions:
 

--- a/src/tests/speed_test.f90
+++ b/src/tests/speed_test.f90
@@ -38,6 +38,28 @@
     real(wp),dimension(nx,ny,nz,nq,nr,ns) :: fcn_6d, bcoef_6d
     real(wp) :: tx(nx+kx),ty(ny+ky),tz(nz+kz),tq(nq+kq),tr(nr+kr),ts(ns+ks)
 
+    real(wp),dimension(3*kx)                     :: w1_1d
+    real(wp),dimension(ky)                       :: w1_2d
+    real(wp),dimension(3*max(kx,ky))             :: w2_2d
+    real(wp),dimension(ky,kz)                    :: w1_3d
+    real(wp),dimension(kz)                       :: w2_3d
+    real(wp),dimension(3*max(kx,ky,kz))          :: w3_3d
+    real(wp),dimension(ky,kz,kq)                 :: w1_4d
+    real(wp),dimension(kz,kq)                    :: w2_4d
+    real(wp),dimension(kq)                       :: w3_4d
+    real(wp),dimension(3*max(kx,ky,kz,kq))       :: w4_4d
+    real(wp),dimension(ky,kz,kq,kr)              :: w1_5d
+    real(wp),dimension(kz,kq,kr)                 :: w2_5d
+    real(wp),dimension(kq,kr)                    :: w3_5d
+    real(wp),dimension(kr)                       :: w4_5d
+    real(wp),dimension(3*max(kx,ky,kz,kq,kr))    :: w5_5d
+    real(wp),dimension(ky,kz,kq,kr,ks)           :: w1_6d
+    real(wp),dimension(kz,kq,kr,ks)              :: w2_6d
+    real(wp),dimension(kq,kr,ks)                 :: w3_6d
+    real(wp),dimension(kr,ks)                    :: w4_6d
+    real(wp),dimension(ks)                       :: w5_6d
+    real(wp),dimension(3*max(kx,ky,kz,kq,kr,ks)) :: w6_6d
+
     real(wp) :: val,sumval
     integer  :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids,iknot,iflag
     real :: tstart, tend
@@ -137,7 +159,7 @@
                 do l=1,nq
                     do m=1,nr
                         do n=1,ns
-                            call db1val(x(i),idx,tx,nx,kx,bcoef_1d,val,iflag,inbvx)
+                            call db1val(x(i),idx,tx,nx,kx,bcoef_1d,val,iflag,inbvx,w1_1d)
                             sumval = sumval + val
                         end do
                     end do
@@ -163,7 +185,7 @@
                         do n=1,ns
                             call db2val(x(i),y(j),idx,idy,tx,ty,&
                                         nx,ny,kx,ky,bcoef_2d,val,iflag,&
-                                        inbvx,inbvy,iloy)
+                                        inbvx,inbvy,iloy,w1_2d,w2_2d)
                            sumval = sumval + val
                        end do
                    end do
@@ -189,7 +211,7 @@
                         do n=1,ns
                             call db3val(x(i),y(j),z(k),idx,idy,idz,tx,ty,tz,&
                                         nx,ny,nz,kx,ky,kz,bcoef_3d,val,iflag,&
-                                        inbvx,inbvy,inbvz,iloy,iloz)
+                                        inbvx,inbvy,inbvz,iloy,iloz,w1_3d,w2_3d,w3_3d)
                             sumval = sumval + val
                         end do
                     end do
@@ -215,7 +237,8 @@
                         do n=1,ns
                             call db4val(x(i),y(j),z(k),q(l),idx,idy,idz,idq,tx,ty,tz,tq,&
                                         nx,ny,nz,nq,kx,ky,kz,kq,bcoef_4d,val,iflag,&
-                                        inbvx,inbvy,inbvz,inbvq,iloy,iloz,iloq)
+                                        inbvx,inbvy,inbvz,inbvq,iloy,iloz,iloq,&
+                                        w1_4d,w2_4d,w3_4d,w4_4d)
                             sumval = sumval + val
                         end do
                     end do
@@ -241,7 +264,8 @@
                         do n=1,ns
                             call db5val(x(i),y(j),z(k),q(l),r(m),idx,idy,idz,idq,idr,tx,ty,tz,tq,tr,&
                                         nx,ny,nz,nq,nr,kx,ky,kz,kq,kr,bcoef_5d,val,iflag,&
-                                        inbvx,inbvy,inbvz,inbvq,inbvr,iloy,iloz,iloq,ilor)
+                                        inbvx,inbvy,inbvz,inbvq,inbvr,iloy,iloz,iloq,ilor,&
+                                        w1_5d,w2_5d,w3_5d,w4_5d,w5_5d)
                             sumval = sumval + val
                         end do
                     end do
@@ -268,7 +292,8 @@
                             call db6val(x(i),y(j),z(k),q(l),r(m),s(n),idx,idy,idz,idq,idr,ids,&
                                         tx,ty,tz,tq,tr,ts,&
                                         nx,ny,nz,nq,nr,ns,kx,ky,kz,kq,kr,ks,bcoef_6d,val,iflag,&
-                                        inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos)
+                                        inbvx,inbvy,inbvz,inbvq,inbvr,inbvs,iloy,iloz,iloq,ilor,ilos,&
+                                        w1_6d,w2_6d,w3_6d,w4_6d,w5_6d,w6_6d)
                             sumval = sumval + val
                         end do
                     end do

--- a/src/tests/speed_test_oo.f90
+++ b/src/tests/speed_test_oo.f90
@@ -8,26 +8,26 @@
     program bspline_speed_test_oo
 
     use bspline_module
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
     use pyplot_module
 
     implicit none
 
-    integer,parameter :: nx = 8   !number of points
-    integer,parameter :: ny = 8
-    integer,parameter :: nz = 8
-    integer,parameter :: nq = 8
-    integer,parameter :: nr = 8
-    integer,parameter :: ns = 8
+    integer(ip),parameter :: nx = 8_ip   !number of points
+    integer(ip),parameter :: ny = 8_ip
+    integer(ip),parameter :: nz = 8_ip
+    integer(ip),parameter :: nq = 8_ip
+    integer(ip),parameter :: nr = 8_ip
+    integer(ip),parameter :: ns = 8_ip
 
-    integer,parameter :: kx = 4    !order
-    integer,parameter :: ky = 4
-    integer,parameter :: kz = 4
-    integer,parameter :: kq = 4
-    integer,parameter :: kr = 4
-    integer,parameter :: ks = 4
+    integer(ip),parameter :: kx = 4_ip    !order
+    integer(ip),parameter :: ky = 4_ip
+    integer(ip),parameter :: kz = 4_ip
+    integer(ip),parameter :: kq = 4_ip
+    integer(ip),parameter :: kr = 4_ip
+    integer(ip),parameter :: ks = 4_ip
 
-    integer,parameter :: n_cases = nx*ny*nz*nq*nr*ns
+    integer(ip),parameter :: n_cases = nx*ny*nz*nq*nr*ns
 
     real(wp) :: x(nx),y(ny),z(nz),q(nq),r(nr),s(ns)
     real(wp) :: fcn_1d(nx)
@@ -45,25 +45,25 @@
     type(bspline_6d) :: s6
 
     real(wp) :: val,sumval
-    integer  :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids,iflag
+    integer(ip)  :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids,iflag
     real :: tstart, tend
     type(pyplot) :: plt
     real(wp),dimension(6) :: cases_per_sec
     integer :: istat  !! pyplot-fortran status flag
 
-    idx = 0
-    idy = 0
-    idz = 0
-    idq = 0
-    idr = 0
-    ids = 0
+    idx = 0_ip
+    idy = 0_ip
+    idz = 0_ip
+    idq = 0_ip
+    idr = 0_ip
+    ids = 0_ip
 
-    x = [ (dble(i), i=1,nx) ]
-    y = [ (dble(i), i=1,ny) ]
-    z = [ (dble(i), i=1,nz) ]
-    q = [ (dble(i), i=1,nq) ]
-    r = [ (dble(i), i=1,nr) ]
-    s = [ (dble(i), i=1,ns) ]
+    x = [ (real(i,wp), i=1,nx) ]
+    y = [ (real(i,wp), i=1,ny) ]
+    z = [ (real(i,wp), i=1,nz) ]
+    q = [ (real(i,wp), i=1,nq) ]
+    r = [ (real(i,wp), i=1,nr) ]
+    s = [ (real(i,wp), i=1,ns) ]
 
     !evaluate the functions:
 

--- a/src/tests/stack_size_test_oo.f90
+++ b/src/tests/stack_size_test_oo.f90
@@ -5,7 +5,7 @@
     program bspline_stack_size_oo_test
 
     use bspline_module
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
 
     implicit none
 
@@ -31,19 +31,19 @@
 
     integer,intent(in) :: n
 
-    integer,parameter :: kx = 4    !order
-    integer,parameter :: ky = 4
-    integer,parameter :: kz = 4
+    integer(ip),parameter :: kx = 4    !order
+    integer(ip),parameter :: ky = 4
+    integer(ip),parameter :: kz = 4
     real(wp),parameter :: tol = 1.0e-14_wp
 
     type(bspline_3d) :: s3
-    integer :: nx,ny,nz
+    integer(ip) :: nx,ny,nz
     real(wp),allocatable :: x(:),y(:),z(:)
     real(wp),allocatable  :: fcn_3d(:,:,:)
     real(wp) :: val,tru,err,errmax
     logical  :: fail
-    integer  :: i,j,k,idx,idy,idz
-    integer  :: iflag
+    integer(ip) :: i,j,k,idx,idy,idz
+    integer(ip) :: iflag
 
     nx = n; ny = n; nz = n
     idx = 0; idy = 0; idz = 0
@@ -55,13 +55,13 @@
     allocate(fcn_3d(nx,ny,nz))
 
      do concurrent (i=1:nx)
-        x(i) = dble(i-1)/dble(nx-1)
+        x(i) = real(i-1,wp)/real(nx-1,wp)
      end do
      do concurrent (j=1:ny)
-        y(j) = dble(j-1)/dble(ny-1)
+        y(j) = real(j-1,wp)/real(ny-1,wp)
      end do
      do concurrent (k=1:nz)
-        z(k) = dble(k-1)/dble(nz-1)
+        z(k) = real(k-1,wp)/real(nz-1,wp)
      end do
 
      do i=1,nx

--- a/src/tests/stack_size_test_oo.f90
+++ b/src/tests/stack_size_test_oo.f90
@@ -1,0 +1,113 @@
+!*****************************************************************************************
+!>
+!  A test of very large data sets for the 3D case.
+
+    program bspline_stack_size_oo_test
+
+    use bspline_module
+    use bspline_kinds_module, only: wp
+
+    implicit none
+
+    integer :: i !! counter
+
+    ! number of data points to test (n x n x n):
+    integer,parameter :: n_start  = 90    !! initial size
+    integer,parameter :: n_stop   = 250   !! final size
+    integer,parameter :: n_step   = 20    !! step size
+
+    write(*,*) ''
+    write(*,'(A10,1X,A20,1X,A30)') 'num points','size (bytes)', 'error'
+    do i = n_start, n_stop, n_step
+        call run_test(i)
+    end do
+    write(*,*) ''
+
+    contains
+
+    subroutine run_test(n)  !! run test for n x n x n data set
+
+    implicit none
+
+    integer,intent(in) :: n
+
+    integer,parameter :: kx = 4    !order
+    integer,parameter :: ky = 4
+    integer,parameter :: kz = 4
+    real(wp),parameter :: tol = 1.0e-14_wp
+
+    type(bspline_3d) :: s3
+    integer :: nx,ny,nz
+    real(wp),allocatable :: x(:),y(:),z(:)
+    real(wp),allocatable  :: fcn_3d(:,:,:)
+    real(wp) :: val,tru,err,errmax
+    logical  :: fail
+    integer  :: i,j,k,l,m,idx,idy,idz
+    integer  :: iflag
+
+    nx = n; ny = n; nz = n
+    idx = 0; idy = 0; idz = 0
+    fail = .false.
+
+    allocate(x(nx))
+    allocate(y(ny))
+    allocate(z(nz))
+    allocate(fcn_3d(nx,ny,nz))
+
+     do concurrent (i=1:nx)
+        x(i) = dble(i-1)/dble(nx-1)
+     end do
+     do concurrent (j=1:ny)
+        y(j) = dble(j-1)/dble(ny-1)
+     end do
+     do concurrent (k=1:nz)
+        z(k) = dble(k-1)/dble(nz-1)
+     end do
+
+     do i=1,nx
+        do j=1,ny
+           do k=1,nz
+              fcn_3d(i,j,k) = f3(x(i),y(j),z(k))
+           end do
+        end do
+     end do
+
+     !initialize:
+     call s3%initialize(x,y,z,fcn_3d,kx,ky,kz,iflag)
+
+     ! free up memory (don't need anymore):
+     deallocate(fcn_3d)
+
+     if (iflag/=0) then
+         write(*,*) 'Error initializing spline: '//get_status_message(iflag)
+         error stop
+     end if
+
+    ! compute max error at interpolation points
+     errmax = 0.0_wp
+     do i=1,nx
+        do j=1,ny
+           do k=1,nz
+                call s3%evaluate(x(i),y(j),z(k),idx,idy,idz,val,iflag)
+                tru    = f3(x(i),y(j),z(k))
+                err    = abs(tru-val)
+                errmax = max(err,errmax)
+           end do
+        end do
+     end do
+
+    ! check max error against tolerance
+    write(*,'(I10,1X,I20,1X,E30.16)') n, s3%size_of()*8, errmax    ! n, size, error
+    if (errmax >= tol) error stop  ' ** test failed ** '
+
+    end subroutine run_test
+
+    pure real(wp) function f3 (x,y,z) !! 3d test function
+    implicit none
+    real(wp),intent(in) :: x,y,z
+    real(wp) :: piov2
+    piov2 = 2.0_wp*atan(1.0_wp)
+    f3 = 0.5_wp*( y*exp(-x) + z*sin(piov2*y) )
+    end function f3
+
+    end program bspline_stack_size_oo_test

--- a/src/tests/stack_size_test_oo.f90
+++ b/src/tests/stack_size_test_oo.f90
@@ -12,9 +12,9 @@
     integer :: i !! counter
 
     ! number of data points to test (n x n x n):
-    integer,parameter :: n_start  = 90    !! initial size
-    integer,parameter :: n_stop   = 250   !! final size
-    integer,parameter :: n_step   = 20    !! step size
+    integer,parameter :: n_start  = 90     !! initial size
+    integer,parameter :: n_stop   = 1000   !! final size
+    integer,parameter :: n_step   = 20     !! step size
 
     write(*,*) ''
     write(*,'(A10,1X,A20,1X,A30)') 'num points','size (bytes)', 'error'

--- a/src/tests/stack_size_test_oo.f90
+++ b/src/tests/stack_size_test_oo.f90
@@ -42,7 +42,7 @@
     real(wp),allocatable  :: fcn_3d(:,:,:)
     real(wp) :: val,tru,err,errmax
     logical  :: fail
-    integer  :: i,j,k,l,m,idx,idy,idz
+    integer  :: i,j,k,idx,idy,idz
     integer  :: iflag
 
     nx = n; ny = n; nz = n

--- a/src/tests/test_integrate.f90
+++ b/src/tests/test_integrate.f90
@@ -40,6 +40,7 @@
     character(len=:),allocatable      :: meth   !! method string
     real(wp)                          :: f_true !! the true integral of
                                                 !! the analytic function
+    real(wp),dimension(:),allocatable :: w1_1d  !! work array
 
     do imeth = 1,2  ! the two methods
 
@@ -48,8 +49,10 @@
 
         do kx = 2, 15  ! spline orders
 
-            if (allocated(tx)) deallocate(tx)
+            if (allocated(tx))    deallocate(tx)
+            if (allocated(w1_1d)) deallocate(w1_1d)
             allocate(tx(nx+kx))
+            allocate(w1_1d(3*kx))
 
             ! x^2 * sin(x) function evaluations for original grid:
             do i=1,nx
@@ -73,10 +76,10 @@
             if (imeth==1) then
                 if (kx>20) cycle
                 meth = 'db1sqad'
-                call db1sqad(tx,fcn,nx,kx,x1,x2,f,iflag)
+                call db1sqad(tx,fcn,nx,kx,x1,x2,f,iflag,w1_1d)
             else
                 meth = 'db1fqad'
-                call db1fqad(test_function,tx,fcn,nx,kx,0,x1,x2,tol,f,iflag)
+                call db1fqad(test_function,tx,fcn,nx,kx,0,x1,x2,tol,f,iflag,w1_1d)
             end if
 
             ! display results:

--- a/src/tests/test_integrate.f90
+++ b/src/tests/test_integrate.f90
@@ -15,26 +15,26 @@
     program bspline_integrate_test
 
     use bspline_module
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
 
     implicit none
 
-    real(wp),parameter :: pi      = acos(-1.0_wp)  !! \( \pi \)
-    real(wp),parameter :: deg2rad = pi/180.0_wp    !! degrees to radians
-    integer,parameter  :: iknot   = 0              !! automatically select the knots
-    real(wp),parameter :: x1      = 0.0_wp         !! left endpoint
-    real(wp),parameter :: x2      = pi             !! right endpoint
-    integer,parameter  :: nx      = 181            !! number of points in x dimension
-                                                   !! in original grid
+    real(wp),parameter     :: pi      = acos(-1.0_wp)  !! \( \pi \)
+    real(wp),parameter     :: deg2rad = pi/180.0_wp    !! degrees to radians
+    integer(ip),parameter  :: iknot   = 0              !! automatically select the knots
+    real(wp),parameter     :: x1      = 0.0_wp         !! left endpoint
+    real(wp),parameter     :: x2      = pi             !! right endpoint
+    integer(ip),parameter  :: nx      = 181            !! number of points in x dimension
+                                                       !! in original grid
     real(wp),parameter :: tol = 10.0_wp*epsilon(1.0_wp)  !! tolerance for [[db1fqad]]
 
     real(wp),dimension(:),allocatable :: tx     !! x knots
-    integer                           :: kx     !! x bspline order
+    integer(ip)                       :: kx     !! x bspline order
     real(wp),dimension(nx)            :: x      !! new grid x points
     real(wp),dimension(nx)            :: fcn    !! original grid
                                                 !! function evaluations
-    integer                           :: i      !! counter
-    integer                           :: iflag  !! status flag
+    integer(ip)                       :: i      !! counter
+    integer(ip)                       :: iflag  !! status flag
     real(wp)                          :: f      !! the evaluated integral
     integer                           :: imeth  !! method counter
     character(len=:),allocatable      :: meth   !! method string
@@ -79,7 +79,7 @@
                 call db1sqad(tx,fcn,nx,kx,x1,x2,f,iflag,w1_1d)
             else
                 meth = 'db1fqad'
-                call db1fqad(test_function,tx,fcn,nx,kx,0,x1,x2,tol,f,iflag,w1_1d)
+                call db1fqad(test_function,tx,fcn,nx,kx,0_ip,x1,x2,tol,f,iflag,w1_1d)
             end if
 
             ! display results:

--- a/src/tests/test_oo.f90
+++ b/src/tests/test_oo.f90
@@ -5,23 +5,23 @@
     program bspline_oo_test
 
     use bspline_module
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
 
     implicit none
 
-    integer,parameter :: nx = 6    !number of points
-    integer,parameter :: ny = 6
-    integer,parameter :: nz = 6
-    integer,parameter :: nq = 6
-    integer,parameter :: nr = 6
-    integer,parameter :: ns = 6
+    integer(ip),parameter :: nx = 6    !number of points
+    integer(ip),parameter :: ny = 6
+    integer(ip),parameter :: nz = 6
+    integer(ip),parameter :: nq = 6
+    integer(ip),parameter :: nr = 6
+    integer(ip),parameter :: ns = 6
 
-    integer,parameter :: kx = 4    !order
-    integer,parameter :: ky = 4
-    integer,parameter :: kz = 4
-    integer,parameter :: kq = 4
-    integer,parameter :: kr = 4
-    integer,parameter :: ks = 4
+    integer(ip),parameter :: kx = 4    !order
+    integer(ip),parameter :: ky = 4
+    integer(ip),parameter :: kz = 4
+    integer(ip),parameter :: kq = 4
+    integer(ip),parameter :: kr = 4
+    integer(ip),parameter :: ks = 4
 
     real(wp) :: x(nx),y(ny),z(nz),q(nq),r(nr),s(ns)
     real(wp) :: fcn_1d(nx)
@@ -41,8 +41,8 @@
     real(wp) :: tol
     real(wp),dimension(6) :: val,tru,err,errmax
     logical  :: fail
-    integer  :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids
-    integer,dimension(6) :: iflag
+    integer(ip)  :: i,j,k,l,m,n,idx,idy,idz,idq,idr,ids
+    integer(ip),dimension(6) :: iflag
 
     fail = .false.
     tol = 1.0e-14_wp
@@ -54,22 +54,22 @@
     ids = 0
 
      do i=1,nx
-        x(i) = dble(i-1)/dble(nx-1)
+        x(i) = real(i-1,wp)/real(nx-1,wp)
      end do
      do j=1,ny
-        y(j) = dble(j-1)/dble(ny-1)
+        y(j) = real(j-1,wp)/real(ny-1,wp)
      end do
      do k=1,nz
-        z(k) = dble(k-1)/dble(nz-1)
+        z(k) = real(k-1,wp)/real(nz-1,wp)
      end do
      do l=1,nq
-        q(l) = dble(l-1)/dble(nq-1)
+        q(l) = real(l-1,wp)/real(nq-1,wp)
      end do
      do m=1,nr
-        r(m) = dble(m-1)/dble(nr-1)
+        r(m) = real(m-1,wp)/real(nr-1,wp)
      end do
      do n=1,ns
-        s(n) = dble(n-1)/dble(ns-1)
+        s(n) = real(n-1,wp)/real(ns-1,wp)
      end do
      do i=1,nx
                         fcn_1d(i) = f1(x(i))
@@ -108,12 +108,12 @@
      end if
 
      write(*,*) ''
-     write(*,*) 'size of 1d structure: ', s1%size_of()*8, 'bytes'
-     write(*,*) 'size of 2d structure: ', s2%size_of()*8, 'bytes'
-     write(*,*) 'size of 3d structure: ', s3%size_of()*8, 'bytes'
-     write(*,*) 'size of 4d structure: ', s4%size_of()*8, 'bytes'
-     write(*,*) 'size of 5d structure: ', s5%size_of()*8, 'bytes'
-     write(*,*) 'size of 6d structure: ', s6%size_of()*8, 'bytes'
+     write(*,*) 'size of 1d structure: ', s1%size_of()*8_ip, 'bytes'
+     write(*,*) 'size of 2d structure: ', s2%size_of()*8_ip, 'bytes'
+     write(*,*) 'size of 3d structure: ', s3%size_of()*8_ip, 'bytes'
+     write(*,*) 'size of 4d structure: ', s4%size_of()*8_ip, 'bytes'
+     write(*,*) 'size of 5d structure: ', s5%size_of()*8_ip, 'bytes'
+     write(*,*) 'size of 6d structure: ', s6%size_of()*8_ip, 'bytes'
      write(*,*) ''
 
     ! compute max error at interpolation points

--- a/src/tests/test_regrid.f90
+++ b/src/tests/test_regrid.f90
@@ -33,6 +33,8 @@
     integer  :: i,j
     integer  :: iflag  !! status flag
     integer  :: inbvx,inbvy,iloy
+    real(wp),dimension(ky)           :: w1 !! work array
+    real(wp),dimension(3*max(kx,ky)) :: w2 !! work array
 
     !function evaluations for original grid:
     do i=1,nx
@@ -69,7 +71,7 @@
         do j=1,ny_new
             y_new(j) = real(j-1,wp)
             call db2val(x_new(i),y_new(j),idx,idy,tx,ty,nx,ny,kx,ky,fcn_2d,val,iflag,&
-                        inbvx,inbvy,iloy)
+                        inbvx,inbvy,iloy,w1,w2)
             if (iflag/=0) error stop 'error calling db2val'
             fcn_new(i,j) = val
             tru    = test_func(x_new(i),y_new(j))  !truth value

--- a/src/tests/test_regrid.f90
+++ b/src/tests/test_regrid.f90
@@ -7,19 +7,19 @@
     program bspline_regridding_test
 
     use bspline_module
-    use bspline_kinds_module, only: wp
+    use bspline_kinds_module, only: wp, ip
 
     implicit none
 
-    integer,parameter :: kx     = 4    !! x bspline order
-    integer,parameter :: ky     = 4    !! y bspline order
-    integer,parameter :: idx    = 0    !! [[db2val]] input
-    integer,parameter :: idy    = 0    !! [[db2val]] input
-    integer,parameter :: nx     = 6    !! number of points in x dimension in original grid
-    integer,parameter :: ny     = 5    !! number of points in y dimension in original grid
-    integer,parameter :: nx_new = 11   !! number of points in x dimension for new grid
-    integer,parameter :: ny_new = 9    !! number of points in y dimension for new grid
-    integer,parameter :: iknot  = 0    !! automatically select the knots
+    integer(ip),parameter :: kx     = 4    !! x bspline order
+    integer(ip),parameter :: ky     = 4    !! y bspline order
+    integer(ip),parameter :: idx    = 0    !! [[db2val]] input
+    integer(ip),parameter :: idy    = 0    !! [[db2val]] input
+    integer(ip),parameter :: nx     = 6    !! number of points in x dimension in original grid
+    integer(ip),parameter :: ny     = 5    !! number of points in y dimension in original grid
+    integer(ip),parameter :: nx_new = 11   !! number of points in x dimension for new grid
+    integer(ip),parameter :: ny_new = 9    !! number of points in y dimension for new grid
+    integer(ip),parameter :: iknot  = 0    !! automatically select the knots
     real(wp),dimension(nx),parameter :: x = [0.0_wp,2.0_wp,4.0_wp,6.0_wp,8.0_wp,10.0_wp]  !! x points in original grid
     real(wp),dimension(ny),parameter :: y = [0.0_wp,2.0_wp,4.0_wp,6.0_wp,8.0_wp]          !! y points in original grid
 
@@ -30,9 +30,9 @@
     real(wp),dimension(ny+ky)         :: ty       !! y knots
     real(wp),dimension(nx,ny)         :: fcn_2d   !! original grid function evaluations
     real(wp) :: val,tru,err,errmax
-    integer  :: i,j
-    integer  :: iflag  !! status flag
-    integer  :: inbvx,inbvy,iloy
+    integer(ip) :: i,j
+    integer(ip) :: iflag  !! status flag
+    integer(ip) :: inbvx,inbvy,iloy
     real(wp),dimension(ky)           :: w1 !! work array
     real(wp),dimension(3*max(kx,ky)) :: w2 !! work array
 


### PR DESCRIPTION
Two changes:
 * The internal work arrays for the `db*ink` routines are now allocated. (so they are on the heap rather than the heap)
 * For the `db*val` routines, the work arrays are now `inout` subroutine arguments. (user can choose to put them on the heap by making them allocatables).

The purpose of these changes is allow for larger sized data sets. Note that the object-oriented interface is unchanged.

Also: 
* The integer kind is now explicitly defined using the `ip` parameter. It is `int32` by default. A user could change it to `int64` to prevent overflow for large data sets. 
* Removed potential stack overflows (see with Intel compiler) for the 3d and 5d `ink` routines.

Fixes #50
Fixes #52
Fixes #53 