### PR TITLE
Update CMake variable LIB_NAME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 # Use MSVS folders to organize projects on windows
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-set( LIB_NAME ${CMAKE_PROJECT_NAME} )
+set( LIB_NAME ${PROJECT_NAME} )
 set( PROJECT_DESCRIPTION
   "Multidimensional B-Spline Interpolation of Data on a Regular Grid" )
 set( PROJECT_URL "https://github.com/jacobwilliams/bspline-fortran" )


### PR DESCRIPTION
Updating LIB_NAME from `${CMAKE_PROJECT_NAME}` to `${PROJECT_NAME}` enables:

- the inclusion of this project as a submodule
- and to use `bspline-fortran-static` as the library in the parent directory, not the parent project name (e.g. `my-super-project-using-awesome-bspline-project-static`.

CMake help for `${PROJECT_NAME}` : This is the name given to the most recently called project() command in the current directory scope or above

See https://cmake.org/cmake/help/latest/variable/PROJECT_NAME.html